### PR TITLE
Updates to support complex validation

### DIFF
--- a/packages/atlaskit/package.json
+++ b/packages/atlaskit/package.json
@@ -39,7 +39,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "0.79.1",
     "flow-types": "^1.0.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest",
+    "glow": "glow",
+    "glow:watch": "glow --watch",
     "start": "webpack-dev-server --mode development",
     "transpile": "babel src -d dist --copy-files",
     "prepublishOnly": "npm run transpile",
@@ -32,7 +34,8 @@
     "css-loader": "^0.28.11",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16.3": "^1.3.0",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "0.79.1",
+    "glow": "^1.1.1",
     "flow-types": "^1.0.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/core/src/components/Form.test.js
+++ b/packages/core/src/components/Form.test.js
@@ -77,7 +77,6 @@ describe("validation warnings", () => {
       name: "field1",
       validWhen: {
         matchesRegEx: {
-          value: "1234",
           pattern: "^[\\d]+$",
           message: "Numbers only"
         }

--- a/packages/core/src/renderer.test.js
+++ b/packages/core/src/renderer.test.js
@@ -71,7 +71,6 @@ describe("Basic single field form capabilities", () => {
   const inputField = wrapper.find("input[type='text']");
   test("changing field value calls onChange", () => {
     inputField.prop("onChange")({ target: { value: "updated" } });
-    // inputField.simulate("change", { target: { value: "updated" } });
     expect(onFormChange).toHaveBeenLastCalledWith({ prop1: "updated" }, true);
   });
 

--- a/packages/core/src/renderer.test.js
+++ b/packages/core/src/renderer.test.js
@@ -70,7 +70,8 @@ describe("Basic single field form capabilities", () => {
 
   const inputField = wrapper.find("input[type='text']");
   test("changing field value calls onChange", () => {
-    inputField.simulate("change", { target: { value: "updated" } });
+    inputField.prop("onChange")({ target: { value: "updated" } });
+    // inputField.simulate("change", { target: { value: "updated" } });
     expect(onFormChange).toHaveBeenLastCalledWith({ prop1: "updated" }, true);
   });
 

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -52,6 +52,12 @@ export type IsNotValue = ({
   message: string
 }) => void | string;
 
+export type IsValue = ({
+  value: Value,
+  values: Array<Value>,
+  message: string
+}) => void | string;
+
 export type ComparedTo = ({
   value: Value,
   fields: string[],
@@ -88,6 +94,11 @@ export type ComparedToConfig = {|
   message?: string
 |};
 
+export type IsValueConfig = {|
+  values: Array<any>,
+  message?: string
+|};
+
 export type IsNotValueConfig = {|
   values: Array<any>,
   message?: string
@@ -99,15 +110,18 @@ export type CoreValidationRules = {|
   matchesRegEx?: MatchesRegExConfig,
   fallsWithinNumericalRange?: FallsWithinNumericalRangeConfig,
   comparedTo?: ComparedToConfig,
-  isNot?: IsNotValueConfig
+  isNot?: IsNotValueConfig,
+  is?: IsValueConfig
+|};
+
+export type Condition = {|
+  field?: string,
+  ...CoreValidationRules
 |};
 
 export type ComplexValidationConfig = {|
   message?: string,
-  conditions: Array<{|
-    field?: string,
-    ...CoreValidationRules
-  |}>
+  conditions: Array<Condition>
 |};
 
 export type ComplexValidation = ({

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -20,18 +20,111 @@ export type OnFieldFocus = (id: string) => void;
 
 export type OnFieldChange = (id: string, value: any) => void;
 
-export type ValidatorId =
-  | "lengthIsGreaterThan"
-  | "lengthIsLessThan"
-  | "matchesRegEx"
-  | "fallsWithinNumericalRange"
-  | "comparedTo";
+export type LengthIsGreaterThan = ({
+  value: Value,
+  length: number,
+  message: string
+}) => void | string;
 
-export type ValidationConfig = any;
+export type LengthIsLessThan = ({
+  value: Value,
+  length: number,
+  message: string
+}) => void | string;
 
-export type ValidationRules = {
-  [key: ValidatorId]: ValidationConfig
-};
+export type MatchesRegEx = ({
+  value: Value,
+  pattern: string,
+  message: string
+}) => void | string;
+
+export type FallsWithinNumericalRange = ({
+  value: Value,
+  min: number,
+  max: number,
+  required?: boolean,
+  message: string
+}) => void | string;
+
+export type IsNotValue = ({
+  value: Value,
+  values: Array<Value>,
+  message: string
+}) => void | string;
+
+export type ComparedTo = ({
+  value: Value,
+  fields: string[],
+  allFields: FieldDef[],
+  is: "SMALLER" | "BIGGER" | "LONGER" | "SHORTER",
+  message: string
+}) => void | string;
+
+export type LengthIsGreaterThanConfig = {|
+  length: number,
+  message?: string
+|};
+
+export type LengthIsLessThanConfig = {|
+  length: number,
+  message?: string
+|};
+
+export type MatchesRegExConfig = {|
+  pattern: string,
+  message?: string
+|};
+
+export type FallsWithinNumericalRangeConfig = {|
+  min: number,
+  max: number,
+  required?: boolean,
+  message?: string
+|};
+
+export type ComparedToConfig = {|
+  fields: string[],
+  is: "SMALLER" | "BIGGER" | "LONGER" | "SHORTER",
+  message?: string
+|};
+
+export type IsNotValueConfig = {|
+  values: Array<any>,
+  message?: string
+|};
+
+export type CoreValidationRules = {|
+  lengthIsGreaterThan?: LengthIsGreaterThanConfig,
+  lengthIsLessThan?: LengthIsLessThanConfig,
+  matchesRegEx?: MatchesRegExConfig,
+  fallsWithinNumericalRange?: FallsWithinNumericalRangeConfig,
+  comparedTo?: ComparedToConfig,
+  isNot?: IsNotValueConfig
+|};
+
+export type ComplexValidationConfig = {|
+  message?: string,
+  conditions: Array<{|
+    field?: string,
+    ...CoreValidationRules
+  |}>
+|};
+
+export type ComplexValidation = ({
+  value: Value,
+  allFields: FieldDef[],
+  message: string,
+  ...ComplexValidationConfig
+}) => string | void;
+
+export type AllAreTrue = ComplexValidation;
+export type SomeAreTrue = ComplexValidation;
+
+export type ValidationRules = {|
+  ...CoreValidationRules,
+  allAreTrue?: ComplexValidationConfig,
+  someAreTrue?: ComplexValidationConfig
+|};
 
 export type Option =
   | {

--- a/packages/core/src/utilities/complex-validation.test.js
+++ b/packages/core/src/utilities/complex-validation.test.js
@@ -3,59 +3,6 @@ import { allAreTrue, someAreTrue } from "./validation";
 import { createField } from "./utils.js";
 import type { FieldDef, ComplexValidationConfig } from "../types";
 
-// Set up field definitions where the validation rule is dependant upon multiple fields
-const fields: FieldDef[] = [
-  {
-    id: "TRIGGER",
-    name: "trigger",
-    type: "text",
-    defaultValue: "off"
-  },
-  {
-    id: "TARGET",
-    name: "target",
-    type: "text",
-    defaultValue: "",
-    validWhen: {
-      allAreTrue: {
-        message: "all have to be true",
-        conditions: [
-          {
-            field: "TRIGGER",
-            matchesRegEx: {
-              pattern: "on"
-            }
-          },
-          {
-            // NOTE: When there is no 'field' - the current field is used
-            matchesRegEx: {
-              pattern: "valid"
-            }
-          }
-        ]
-      },
-      someAreTrue: {
-        message: "some are true",
-        conditions: [
-          {
-            field: "TRIGGER",
-            isNot: {
-              values: ["off"],
-              message: "something"
-            }
-          },
-          {
-            isNot: {
-              values: ["false"],
-              message: "Don't be bob when trigger is off"
-            }
-          }
-        ]
-      }
-    }
-  }
-];
-
 const allAreTrueExample: ComplexValidationConfig = {
   message: "fail",
   conditions: [

--- a/packages/core/src/utilities/complex-validation.test.js
+++ b/packages/core/src/utilities/complex-validation.test.js
@@ -108,3 +108,38 @@ describe("allAreTrue", () => {
     ).toBe("fail");
   });
 });
+
+describe("someAreTrue", () => {
+  triggerField.value = "off";
+  targetField.value = "valid";
+  test("should pass when both conditions are true", () => {
+    expect(
+      someAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBeUndefined();
+  });
+  test("should still pass when one condition is false", () => {
+    triggerField.value = "on";
+    expect(
+      someAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBeUndefined();
+  });
+  test("should fail pass when both conditions are false", () => {
+    triggerField.value = "on";
+    targetField.value = "invalid";
+    expect(
+      someAreTrue({
+        value: "invalid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBe("fail");
+  });
+});

--- a/packages/core/src/utilities/complex-validation.test.js
+++ b/packages/core/src/utilities/complex-validation.test.js
@@ -17,13 +17,11 @@ const fields: FieldDef[] = [
     type: "text",
     defaultValue: "",
     validWhen: {
-      // matchesRegEx: {},
       allAreTrue: {
         message: "all have to be true",
         conditions: [
           {
             field: "TRIGGER",
-            //   isNot:
             matchesRegEx: {
               pattern: "on"
             }
@@ -59,19 +57,17 @@ const fields: FieldDef[] = [
 ];
 
 const allAreTrueExample: ComplexValidationConfig = {
-  message: "all have to be true",
+  message: "fail",
   conditions: [
     {
       field: "TRIGGER",
-      //   isNot:
-      matchesRegEx: {
-        pattern: "on"
+      isNot: {
+        values: ["on"]
       }
     },
     {
-      // NOTE: When there is no 'field' - the current field is used
-      matchesRegEx: {
-        pattern: "valid"
+      isNot: {
+        values: ["invalid"]
       }
     }
   ]
@@ -80,7 +76,7 @@ const allAreTrueExample: ComplexValidationConfig = {
 const triggerField = createField({
   id: "TRIGGER",
   name: "trigger",
-  value: "on"
+  value: "off"
 });
 
 const targetField = createField({
@@ -92,7 +88,7 @@ const targetField = createField({
 const allFields = [triggerField, targetField];
 
 describe("allAreTrue", () => {
-  test("needs a name", () => {
+  test("should pass when both conditions are true", () => {
     expect(
       allAreTrue({
         value: "valid",
@@ -100,5 +96,15 @@ describe("allAreTrue", () => {
         ...allAreTrueExample
       })
     ).toBeUndefined();
+  });
+  test("should fail when one conditions is false", () => {
+    triggerField.value = "on";
+    expect(
+      allAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBe("fail");
   });
 });

--- a/packages/core/src/utilities/complex-validation.test.js
+++ b/packages/core/src/utilities/complex-validation.test.js
@@ -1,0 +1,104 @@
+// @flow
+import { allAreTrue, someAreTrue } from "./validation";
+import { createField } from "./utils.js";
+import type { FieldDef, ComplexValidationConfig } from "../types";
+
+// Set up field definitions where the validation rule is dependant upon multiple fields
+const fields: FieldDef[] = [
+  {
+    id: "TRIGGER",
+    name: "trigger",
+    type: "text",
+    defaultValue: "off"
+  },
+  {
+    id: "TARGET",
+    name: "target",
+    type: "text",
+    defaultValue: "",
+    validWhen: {
+      // matchesRegEx: {},
+      allAreTrue: {
+        message: "all have to be true",
+        conditions: [
+          {
+            field: "TRIGGER",
+            //   isNot:
+            matchesRegEx: {
+              pattern: "on"
+            }
+          },
+          {
+            // NOTE: When there is no 'field' - the current field is used
+            matchesRegEx: {
+              pattern: "valid"
+            }
+          }
+        ]
+      },
+      someAreTrue: {
+        message: "some are true",
+        conditions: [
+          {
+            field: "TRIGGER",
+            isNot: {
+              values: ["off"],
+              message: "something"
+            }
+          },
+          {
+            isNot: {
+              values: ["false"],
+              message: "Don't be bob when trigger is off"
+            }
+          }
+        ]
+      }
+    }
+  }
+];
+
+const allAreTrueExample: ComplexValidationConfig = {
+  message: "all have to be true",
+  conditions: [
+    {
+      field: "TRIGGER",
+      //   isNot:
+      matchesRegEx: {
+        pattern: "on"
+      }
+    },
+    {
+      // NOTE: When there is no 'field' - the current field is used
+      matchesRegEx: {
+        pattern: "valid"
+      }
+    }
+  ]
+};
+
+const triggerField = createField({
+  id: "TRIGGER",
+  name: "trigger",
+  value: "on"
+});
+
+const targetField = createField({
+  id: "TARGET",
+  name: "target",
+  value: "valid"
+});
+
+const allFields = [triggerField, targetField];
+
+describe("allAreTrue", () => {
+  test("needs a name", () => {
+    expect(
+      allAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -1,44 +1,18 @@
 // @flow
 import type {
+  AllAreTrue,
+  ComparedTo,
+  FallsWithinNumericalRange,
   FieldDef,
+  IsNotValue,
+  LengthIsGreaterThan,
+  LengthIsLessThan,
+  MatchesRegEx,
+  SomeAreTrue,
   Value,
   ValidateField,
   ValidateAllFields
 } from "../types";
-
-export type LengthIsGreaterThan = ({
-  value: Value,
-  length: number,
-  message: string
-}) => void | string;
-
-export type LengthIsLessThan = ({
-  value: Value,
-  length: number,
-  message: string
-}) => void | string;
-
-export type MatchesRegEx = ({
-  value: Value,
-  pattern: string,
-  message: string
-}) => void | string;
-
-export type FallsWithinNumericalRange = ({
-  value: Value,
-  min?: number,
-  max?: number,
-  required?: boolean,
-  message: string
-}) => void | string;
-
-export type ComparedTo = ({
-  value: Value,
-  fields: string[],
-  allFields: FieldDef[],
-  is: "SMALLER" | "BIGGER" | "LONGER" | "SHORTER",
-  message: string
-}) => void | string;
 
 export const findFieldsToCompareTo = (
   fieldsToFind: string[],
@@ -211,12 +185,41 @@ export const fallsWithinNumericalRange: FallsWithinNumericalRange = ({
   }
 };
 
+export const isNotValue: IsNotValue = ({ value, values, message }) => {
+  if (values.some(currValue => currValue === value)) {
+    return message || "Unacceptable value provided";
+  }
+};
+
+export const someAreTrue: SomeAreTrue = ({
+  value,
+  allFields,
+  message,
+  conditions
+}) => {
+  // TODO: Implement
+  return undefined;
+};
+
+export const allAreTrue: AllAreTrue = ({
+  value,
+  allFields,
+  message,
+  conditions
+}) => {
+  // TODO: Implement
+  return undefined;
+};
+
 export const validators = {
+  allAreTrue,
+  comparedTo,
+  fallsWithinNumericalRange,
+  isNot: isNotValue,
   lengthIsGreaterThan,
   lengthIsLessThan,
   matchesRegEx,
-  fallsWithinNumericalRange,
-  comparedTo
+  someAreTrue
 };
 
 export const validateField: ValidateField = (
@@ -242,12 +245,11 @@ export const validateField: ValidateField = (
       Object.keys(validWhen).reduce((allValidatorsPass, validator) => {
         if (typeof validators[validator] === "function") {
           let validationConfig = {
-            // $FlowFixMe
             ...validWhen[validator],
             value,
             allFields: fields
           };
-
+          // $FlowFixMe - covered by tests
           let message = validators[validator](validationConfig);
           if (message) {
             allValidatorsPass = false;

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -7,6 +7,7 @@ import {
   isBigger,
   isLonger,
   isNotValue,
+  isValue,
   isShorter,
   lengthIsGreaterThan,
   lengthIsLessThan,
@@ -429,6 +430,28 @@ describe("comparedTo", () => {
         message: "Fail"
       })
     ).toBeUndefined();
+  });
+});
+
+describe("isValue", () => {
+  test("matching value does not cause error", () => {
+    expect(
+      isValue({
+        value: "bob",
+        values: ["bob", "ted", "geoff"],
+        message: "Fail"
+      })
+    ).toBeUndefined();
+  });
+
+  test("non-matching value causes error", () => {
+    expect(
+      isValue({
+        value: "sally",
+        values: ["bob", "ted", "geoff"],
+        message: "Fail"
+      })
+    ).toBe("Fail");
   });
 });
 

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -6,6 +6,7 @@ import {
   getDefaultNumericalRangeErrorMessages,
   isBigger,
   isLonger,
+  isNotValue,
   isShorter,
   lengthIsGreaterThan,
   lengthIsLessThan,
@@ -198,12 +199,14 @@ describe("getDefaultNumericalRangeErrorMessages", () => {
 describe("fallsWithinNumericalRange", () => {
   test("fails when given a non-numerical number", () => {
     expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
       fallsWithinNumericalRange({ value: "abc", min: 5, message: "Fail" })
     ).toBe("Fail");
   });
 
   test("succeeds with just a min", () => {
     expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
       fallsWithinNumericalRange({
         value: "5",
         min: 1,
@@ -214,6 +217,7 @@ describe("fallsWithinNumericalRange", () => {
 
   test("succeeds with just a max", () => {
     expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
       fallsWithinNumericalRange({
         value: 6,
         max: 10,
@@ -224,6 +228,7 @@ describe("fallsWithinNumericalRange", () => {
 
   test("fails with just a min", () => {
     expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
       fallsWithinNumericalRange({
         value: "5",
         min: 10,
@@ -234,6 +239,7 @@ describe("fallsWithinNumericalRange", () => {
 
   test("fails with just a max", () => {
     expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
       fallsWithinNumericalRange({
         value: 6,
         max: 5,
@@ -420,6 +426,28 @@ describe("comparedTo", () => {
         fields: ["SHORTEST"],
         allFields,
         is: "SHORTER",
+        message: "Fail"
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe("isNotValue", () => {
+  test("matching value causes error", () => {
+    expect(
+      isNotValue({
+        value: "bob",
+        values: ["bob", "ted", "geoff"],
+        message: "Fail"
+      })
+    ).toBe("Fail");
+  });
+
+  test("non-matching value returns undefined", () => {
+    expect(
+      isNotValue({
+        value: "sally",
+        values: ["bob", "ted", "geoff"],
         message: "Fail"
       })
     ).toBeUndefined();

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -37,7 +37,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "0.79.1",
     "flow-types": "^1.0.0",
     "gh-pages": "^1.1.0",
     "html-loader": "^0.5.5",

--- a/packages/formbuilder/package.json
+++ b/packages/formbuilder/package.json
@@ -31,7 +31,7 @@
     "css-loader": "^0.28.11",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16.3": "^1.3.0",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "0.79.1",
     "flow-types": "^1.0.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -27,7 +27,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "0.79.1",
     "flow-types": "^1.0.0",
     "gh-pages": "^1.1.0",
     "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,6 +302,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.46"
 
+"@babel/code-frame@^7.0.0-beta.38":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/helper-module-imports@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.51.tgz#ce00428045fbb7d5ebc0ea7bf835789f15366ab2"
@@ -316,6 +322,14 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
 
 "@babel/runtime-corejs2@^7.0.0":
   version "7.0.0"
@@ -1701,6 +1715,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+beeper@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1712,6 +1730,10 @@ binary-extensions@^1.0.0:
 binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
+
+blessed@^0.1.81:
+  version "0.1.81"
+  resolved "https://registry.yarnpkg.com/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
 
 bluebird@^3.5.1:
   version "3.5.1"
@@ -2212,6 +2234,10 @@ clean-css@4.1.x:
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
   dependencies:
     source-map "0.5.x"
+
+clear@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/clear/-/clear-0.0.1.tgz#e5186e229d99448179c130311b6f9d30bff6b0ba"
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -2744,7 +2770,7 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -3915,9 +3941,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.72.0:
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.72.0.tgz#12051180fb2db7ccb728fefe67c77e955e92a44d"
+flow-bin@0.79.1:
+  version "0.79.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.1.tgz#01c9f427baa6556753fa878c192d42e1ecb764b6"
 
 flow-copy-source@^2.0.2:
   version "2.0.2"
@@ -4263,6 +4289,27 @@ globby@^8.0.0:
     ignore "^3.3.5"
     pify "^3.0.0"
     slash "^1.0.0"
+
+glow@^1.1.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/glow/-/glow-1.2.2.tgz#41630d723483a89c4a3add3cc5871f775daa3036"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.38"
+    babel-runtime "^6.26.0"
+    beeper "^1.1.1"
+    blessed "^0.1.81"
+    chalk "^2.3.0"
+    chokidar "^2.0.0"
+    clear "^0.0.1"
+    find-up "^2.1.0"
+    lodash.debounce "^4.0.8"
+    meow "^4.0.0"
+    multimatch "^2.1.0"
+    read-pkg-up "^3.0.0"
+    signal-exit "^3.0.2"
+    spawndamnit "^1.0.0"
+    strip-ansi "^4.0.0"
+    util.promisify "^1.0.0"
 
 got@^6.7.1:
   version "6.7.1"
@@ -5539,6 +5586,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.7.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -6016,6 +6067,10 @@ lodash._reinterpolate@~3.0.0:
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.escape@^4.0.1:
   version "4.0.1"
@@ -6501,7 +6556,7 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-multimatch@^2.0.0:
+multimatch@^2.0.0, multimatch@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
   dependencies:
@@ -8755,6 +8810,13 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
 source-map@^0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+
+spawndamnit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/spawndamnit/-/spawndamnit-1.0.0.tgz#b5d4a1a73016dbcca8f8b1e283eee76a649161b8"
+  dependencies:
+    cross-spawn "^5.1.0"
+    signal-exit "^3.0.2"
 
 spdx-correct@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR improves validation options so that it is now possible to use `isNot` and `is` to compare values of a field (as a simple alternative to `matchesRegEx`.

It is now also possible to build rules in the form...

```
validWhen: {
  allAreTrue: {
     message: 'Error message when all are not true',
     conditions: [
        {
           field: 'FIELD1',
           matchesRegEx: {
```

(where you can swap `matchesRegEx` with any of the other validators (`is`, `isNot`, `lengthIsGreaterThan`, `fallsWithinNumericalRange`, etc).

This allows you to create validation rules where the validation is conditional based on the state of other fields.

The specific use case this addresses was an example where an option in a drop-down menu should not be allowed if another field has a certain value. A workaround would have been to have removed the option (using a custom optionsHandler) but the value here is in being able to provide a message that explains the problem).

You can also use `someAreTrue` if you just need to check that at least one condition matches.

Where a `field` is not specified the value of the current field (i.e. the field that this rule has been configured for) is tested.