### PR TITLE
Added an example of complex validation and also a 'noneAreTrue' option

### DIFF
--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -133,11 +133,13 @@ export type ComplexValidation = ({
 
 export type AllAreTrue = ComplexValidation;
 export type SomeAreTrue = ComplexValidation;
+export type NoneAreTrue = ComplexValidation;
 
 export type ValidationRules = {|
   ...CoreValidationRules,
   allAreTrue?: ComplexValidationConfig,
-  someAreTrue?: ComplexValidationConfig
+  someAreTrue?: ComplexValidationConfig,
+  noneAreTrue?: ComplexValidationConfig
 |};
 
 export type Option =

--- a/packages/core/src/utilities/complex-validation.test.js
+++ b/packages/core/src/utilities/complex-validation.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { allAreTrue, someAreTrue } from "./validation";
+import { allAreTrue, noneAreTrue, someAreTrue } from "./validation";
 import { createField } from "./utils.js";
 import type { FieldDef, ComplexValidationConfig } from "../types";
 
@@ -78,7 +78,7 @@ describe("someAreTrue", () => {
       })
     ).toBeUndefined();
   });
-  test("should fail pass when both conditions are false", () => {
+  test("should fail when both conditions are false", () => {
     triggerField.value = "on";
     targetField.value = "invalid";
     expect(
@@ -88,5 +88,40 @@ describe("someAreTrue", () => {
         ...allAreTrueExample
       })
     ).toBe("fail");
+  });
+});
+
+describe("noneAreTrue", () => {
+  triggerField.value = "off";
+  targetField.value = "valid";
+  test("should fail when both conditions are true", () => {
+    expect(
+      noneAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBe("fail");
+  });
+  test("should still fail when one condition is false", () => {
+    triggerField.value = "on";
+    expect(
+      noneAreTrue({
+        value: "valid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBe("fail");
+  });
+  test("should pass when both conditions are false", () => {
+    triggerField.value = "on";
+    targetField.value = "invalid";
+    expect(
+      noneAreTrue({
+        value: "invalid",
+        allFields,
+        ...allAreTrueExample
+      })
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -224,7 +224,7 @@ export const checkConditions = (
   condition: Condition,
   value: Value,
   allFields: FieldDef[],
-  type: "none" | "some" | "all"
+  type: "some" | "all"
 ) => {
   let valueToTest; // Don't initialise to current field value in case field doesn't exist
   if (condition.field) {

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -224,7 +224,7 @@ export const checkConditions = (
   condition: Condition,
   value: Value,
   allFields: FieldDef[],
-  type: "some" | "all"
+  type: "none" | "some" | "all"
 ) => {
   let valueToTest; // Don't initialise to current field value in case field doesn't exist
   if (condition.field) {
@@ -237,14 +237,32 @@ export const checkConditions = (
   }
 
   const { field, ...validWhen } = condition;
-  if (type === "some") {
-    return Object.keys(validWhen).some(validatorKey =>
-      runValidator(validatorKey, condition, valueToTest, allFields)
-    );
+  switch (type) {
+    case "some": {
+      return Object.keys(validWhen).some(validatorKey =>
+        runValidator(validatorKey, condition, valueToTest, allFields)
+      );
+    }
+
+    default: {
+      return Object.keys(validWhen).every(validatorKey =>
+        runValidator(validatorKey, condition, valueToTest, allFields)
+      );
+    }
   }
-  return Object.keys(validWhen).every(validatorKey =>
-    runValidator(validatorKey, condition, valueToTest, allFields)
+};
+
+export const noneAreTrue: AllAreTrue = ({
+  value,
+  allFields,
+  message,
+  conditions
+}): string | void => {
+  const allConditionsPass = conditions.some(condition =>
+    checkConditions(condition, value, allFields, "some")
   );
+
+  return allConditionsPass ? message : undefined;
 };
 
 export const someAreTrue: SomeAreTrue = ({
@@ -282,6 +300,7 @@ export const validators = {
   lengthIsGreaterThan,
   lengthIsLessThan,
   matchesRegEx,
+  noneAreTrue,
   someAreTrue
 };
 

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -10,6 +10,7 @@ import type {
   LengthIsGreaterThan,
   LengthIsLessThan,
   MatchesRegEx,
+  NoneAreTrue,
   SomeAreTrue,
   Value,
   ValidateField,
@@ -252,7 +253,7 @@ export const checkConditions = (
   }
 };
 
-export const noneAreTrue: AllAreTrue = ({
+export const noneAreTrue: NoneAreTrue = ({
   value,
   allFields,
   message,

--- a/packages/examples/src/tutorial/Tutorial.js
+++ b/packages/examples/src/tutorial/Tutorial.js
@@ -9,7 +9,8 @@ import {
   manipulateOptions,
   duplicateNames,
   validation,
-  comparisonValidation
+  comparisonValidation,
+  complexValidation
 } from "./definitions";
 import type { FieldRenderer, OptionsHandler } from "react-forms-processor";
 import { getOptions } from "../SwapiOptionsHandler";
@@ -30,6 +31,8 @@ import duplicateNamesDescription from "./tutorial6.md";
 import validationDescription from "./tutorial7.md";
 // $FlowFixMe
 import comparisonValidationDescription from "./tutorial8.md";
+// $FlowFixMe
+import complexValidationDescription from "./tutorial9.md";
 
 const swapiOptions: OptionsHandler = (fieldId, fields, parentContext) => {
   return getOptions();
@@ -98,6 +101,12 @@ class Tutorial extends Component<TutorialProps, *> {
           defaultDefinition={JSON.stringify(comparisonValidation)}
           editorTitle="Validating against other fields"
           editorDescription={comparisonValidationDescription}
+          renderer={renderer}
+        />
+        <LiveEditor
+          defaultDefinition={JSON.stringify(complexValidation)}
+          editorTitle="Complex validation"
+          editorDescription={complexValidationDescription}
           renderer={renderer}
         />
       </article>

--- a/packages/examples/src/tutorial/definitions.js
+++ b/packages/examples/src/tutorial/definitions.js
@@ -177,9 +177,12 @@ export const validation: FieldDef[] = [
         message: "The value must be more than 150 and less than 80000"
       },
       matchesRegEx: {
-        value: "1234",
         pattern: "^[\\d]+$",
         message: "Only numbers allowed"
+      },
+      isNot: {
+        values: ["2500", "4001"],
+        message: "The value cannot be 2500 nor 4001"
       }
     }
   }
@@ -225,6 +228,49 @@ export const comparisonValidation: FieldDef[] = [
       comparedTo: {
         fields: ["ONE", "TWO"],
         is: "SMALLER"
+      }
+    }
+  }
+];
+
+export const complexValidation: FieldDef[] = [
+  {
+    id: "LENGTH_REQUIREMENTS",
+    name: "length",
+    type: "radiogroup",
+    label: "How long should the name be?",
+    defaultValue: "Small",
+    description: "Choose the length requirements for the name field",
+    options: [
+      {
+        items: ["Small", "Medium", "Large"]
+      }
+    ]
+  },
+  {
+    id: "NAME",
+    name: "name",
+    type: "text",
+    label: "Name?",
+    defaultValue: "",
+    description:
+      "A name (the length required is determined by the field above)",
+    validWhen: {
+      someAreTrue: {
+        message: "Length must be less than 5 when size is small",
+        conditions: [
+          {
+            field: "LENGTH_REQUIREMENTS",
+            is: {
+              values: ["Medium", "Large"]
+            }
+          },
+          {
+            lengthIsLessThan: {
+              length: 5
+            }
+          }
+        ]
       }
     }
   }

--- a/packages/examples/src/tutorial/tutorial9.md
+++ b/packages/examples/src/tutorial/tutorial9.md
@@ -1,0 +1,3 @@
+Sometimes it is necessary to create more complex validations where the validity of a field is linked to the values assigned to other fields.
+
+In this example the `NAME` field must be less than 5 characters long when the `LENGTH_REQUIREMENTS` field is 'Small'. This has been defined as the `NAME` field is only valid when either the `LENGTH_REQUIREMENTS` field is either 'Medium' or 'Large' or the `NAME` field has less than 5 characters.


### PR DESCRIPTION
This PR adds some examples of complex validation addressing #10 and using the implementation added for #11.

I'm not 100% sure this is going to cover all the cases - we might want to further extend this to allow nested complex validation, e.g. someAreTrue of the following 3 allAreTrue clauses (at the moment this is not possible - or at least causes typing problems.

I've also added a `noneAreTrue` option as well.