### PR TITLE
allow undefined or null

### DIFF
--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -181,7 +181,7 @@ export const fallsWithinNumericalRange: FallsWithinNumericalRange = ({
 }) => {
   const parsedValue = parseFloat(value);
 
-  if (typeof value === "string" && !value.length) {
+  if (!value || (typeof value === "string" && !value.length)) {
     return undefined;
   }
 

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -261,6 +261,41 @@ describe("fallsWithinNumericalRange", () => {
     ).toBeUndefined();
   });
 
+  test("succeeds with null", () => {
+    expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
+      fallsWithinNumericalRange({
+        value: null,
+        min: 0,
+        max: 5,
+        message: "Fail"
+      })
+    ).toBeUndefined();
+  });
+  test("succeeds with string null", () => {
+    expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
+      fallsWithinNumericalRange({
+        value: null,
+        min: 0,
+        max: 5,
+        message: "Fail"
+      })
+    ).toBeUndefined();
+  });
+
+  test("succeeds with undefined", () => {
+    expect(
+      // $FlowFixMe - Typing should prevent this, but we're testing the output
+      fallsWithinNumericalRange({
+        value: undefined,
+        min: 0,
+        max: 5,
+        message: "Fail"
+      })
+    ).toBeUndefined();
+  });
+
   test("fails with whitespace", () => {
     expect(
       // $FlowFixMe - Typing should prevent this, but we're testing the output


### PR DESCRIPTION
One more thing which I missed in the previous PR.
Might be better don't run validation if we do not have value or it's empty since it has handled with the required  property but I'm not sure if it would work fine with other types of validation 