### PR TITLE
Add support for custom error message for missing required fields

### DIFF
--- a/packages/core/src/renderer.test.js
+++ b/packages/core/src/renderer.test.js
@@ -250,7 +250,7 @@ describe("2 fields sharing name", () => {
     form.update();
 
     setTimeout(() => {
-      console.log(form.debug());
+      // console.log(form.debug());
 
       // TODO: This test will fail - it needs to pass!
       // expect(form.find("input[type='text']").length).toBe(1);

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -190,6 +190,7 @@ export type FieldDef = {
   value?: void | string | number | boolean | Array<any>,
   visible?: boolean,
   required?: boolean,
+  missingValueMessage?: string,
   defaultDisabled?: boolean,
   disabled?: boolean,
   disabledWhen?: Rule[],

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -327,7 +327,8 @@ export const validateField: ValidateField = (
       const valueIsEmptyArray = Array.isArray(value) && value.length === 0;
       isValid = (value || value === 0 || value === false) && !valueIsEmptyArray;
       if (!isValid) {
-        errorMessages.push("A value must be provided");
+        const { missingValueMessage = "A value must be provided" } = field;
+        errorMessages.push(missingValueMessage);
       }
     }
 

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -78,7 +78,7 @@ describe("validateField", () => {
     expect(validateField(testField, [testField], true).isValid).toBe(true);
   });
 
-  test("visible, required field with empty array value is valid", () => {
+  test("visible, required field with empty array value is invalid", () => {
     const testField = {
       ...field1,
       visible: true,
@@ -96,6 +96,20 @@ describe("validateField", () => {
       value: [1]
     };
     expect(validateField(testField, [testField], true).isValid).toBe(true);
+  });
+
+  test("visible, required field with missing data shows custom message", () => {
+    const errorMessage = "Where's my data?";
+    const testField = {
+      ...field1,
+      visible: true,
+      required: true,
+      value: "",
+      missingValueMessage: errorMessage
+    };
+    const validationResult = validateField(testField, [testField], true);
+    expect(validationResult.isValid).toBe(false);
+    expect(validationResult.errorMessages).toBe(errorMessage);
   });
 
   test("using validation handler reporting invalid", () => {


### PR DESCRIPTION
Fixes #19 by making it possible to provide an optional `missingValueMessage` on a field that is shown when a field with `required` true has no value.