### PR TITLE
Fix trimming behaviour

### DIFF
--- a/packages/core/src/utilities/utils.js
+++ b/packages/core/src/utilities/utils.js
@@ -196,13 +196,6 @@ export const processFields: ProcessFields = (fields, formIsDisabled) => {
     } = field;
 
     let processedValue = typeof value !== "undefined" ? value : defaultValue;
-    if (
-      trimValue &&
-      processedValue &&
-      typeof processedValue.trim === "function"
-    ) {
-      processedValue = processedValue.trim();
-    }
 
     return {
       ...field,
@@ -398,7 +391,7 @@ export const shouldOmitFieldValue: OmitFieldValue = field => {
 
 export const calculateFormValue: CalculateFormValue = fields => {
   return fields.reduce((formValue, field) => {
-    const { name, value, useChangesAsValues } = field;
+    const { name, value, trimValue, useChangesAsValues } = field;
     if (shouldOmitFieldValue(field)) {
       return formValue;
     } else if (useChangesAsValues) {
@@ -406,7 +399,15 @@ export const calculateFormValue: CalculateFormValue = fields => {
         set(formValue, name, value)
       );
     } else {
-      set(formValue, name, value);
+      let processedValue = value;
+      if (
+        trimValue &&
+        processedValue &&
+        typeof processedValue.trim === "function"
+      ) {
+        processedValue = processedValue.trim();
+      }
+      set(formValue, name, processedValue);
     }
 
     return formValue;

--- a/packages/core/src/utilities/utils.test.js
+++ b/packages/core/src/utilities/utils.test.js
@@ -346,6 +346,13 @@ describe("calculateFormValue", () => {
     name: "test.dot.notation",
     value: "ted"
   };
+  const fieldToTrim = {
+    ...baseField,
+    id: "TEST6",
+    name: "testTrim",
+    value: "     trimmed     ",
+    trimValue: true
+  };
 
   const value = calculateFormValue([field1, field2, field3, field4]);
   test("two field values should be omitted", () => {
@@ -388,6 +395,11 @@ describe("calculateFormValue", () => {
   //   const value = calculateFormValue([field1]);
   //   expect(value.some.nested.prop).toEqual("foo");
   // });
+
+  test("field value can be trimmed", () => {
+    const value = calculateFormValue([fieldToTrim]);
+    expect(value.testTrim).toBe("trimmed");
+  });
 });
 
 describe("updateFieldValue", () => {
@@ -511,18 +523,19 @@ describe("default value handling", () => {
 });
 
 describe("trimming behaviour", () => {
+  const value = "   foo     ";
   const field: FieldDef = {
     id: "TO_BE_TRIMMED",
     name: "test",
     type: "text",
-    value: "   foo     ",
+    value,
     trimValue: true
   };
 
-  test("leading and trailing whitespace is removed from value", () => {
+  test("leading and trailing whitespace is NOT removed from when processed", () => {
     const processedFields = processFields([field], false);
     const trimmedField = processedFields[0];
-    expect(trimmedField.value).toEqual("foo");
+    expect(trimmedField.value).toEqual(value);
   });
 });
 

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -312,6 +312,22 @@ export const validators = {
   someAreTrue
 };
 
+export const hasValue = (value: Value): boolean => {
+  const valueIsEmptyArray = Array.isArray(value) && value.length === 0;
+  const hasNoValue =
+    (value || value === 0 || value === false) && !valueIsEmptyArray;
+  return !hasNoValue;
+};
+
+export const getValueFromField = (field: FieldDef): Value => {
+  const { trimValue = false, value } = field;
+  let trimmedValue = value;
+  if (trimValue && trimmedValue && typeof trimmedValue.trim === "function") {
+    trimmedValue = trimmedValue.trim();
+  }
+  return trimmedValue;
+};
+
 export const validateField: ValidateField = (
   field,
   fields,
@@ -319,13 +335,13 @@ export const validateField: ValidateField = (
   validationHandler,
   parentContext
 ) => {
-  const { required, visible, value, validWhen = {}, touched = false } = field;
+  const { required, visible, validWhen = {}, touched = false } = field;
   let isValid = true;
   let errorMessages = [];
   if (visible) {
+    const value = getValueFromField(field);
     if (required) {
-      const valueIsEmptyArray = Array.isArray(value) && value.length === 0;
-      isValid = (value || value === 0 || value === false) && !valueIsEmptyArray;
+      isValid = !hasValue(value);
       if (!isValid) {
         const { missingValueMessage = "A value must be provided" } = field;
         errorMessages.push(missingValueMessage);

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -133,6 +133,29 @@ describe("validateField", () => {
       validateField(testField, [testField], true, validationHandler).isValid
     ).toBe(true);
   });
+
+  test("validation of trimmed and required field with whitespace value is false", () => {
+    const testField = {
+      ...field1,
+      visible: true,
+      required: true,
+      value: "     ",
+      trimValue: true
+    };
+    const validationResult = validateField(testField, [testField], true);
+    expect(validationResult.isValid).toBe(false);
+  });
+
+  test("validation of untrimmed and required field with whitespace value is true", () => {
+    const testField = {
+      ...field1,
+      visible: true,
+      required: true,
+      value: "     "
+    };
+    const validationResult = validateField(testField, [testField], true);
+    expect(validationResult.isValid).toBe(true);
+  });
 });
 
 describe("lengthIsGreaterThan validator", () => {


### PR DESCRIPTION
This PR fixes #20 by making updates to only trim before validation and when calculating form value and not for every change of value to a field. This means that it should be possible to enter white space within text and not have it filtered out.