### PR TITLE
Reset the touched state of all the fields when a new value is passed as a prop to a form

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   },
   "jest": {
     "verbose": true,
-    "bail": true,
+    "bail": false,
     "rootDir": "src"
   }
 }

--- a/packages/core/src/components/Form.test.js
+++ b/packages/core/src/components/Form.test.js
@@ -169,3 +169,49 @@ describe("validation warnings", () => {
     });
   });
 });
+
+describe("changing form value prop", () => {
+  const fields: FieldDef[] = [
+    {
+      id: "FIELD1",
+      type: "text",
+      name: "field1",
+      validWhen: {
+        matchesRegEx: {
+          pattern: "^[\\d]+$",
+          message: "Numbers only"
+        }
+      }
+    }
+  ];
+
+  const onButtonClick = jest.fn();
+  const formValue1 = {
+    field1: "value1"
+  };
+  const formValue2 = {
+    field1: "value2"
+  };
+
+  const form = mount(
+    <Form value={formValue1}>
+      <FormFragment defaultFields={fields} />
+    </Form>
+  );
+
+  test("field has not been touched", () => {
+    expect(form.state().fields[0].touched).toBe(false);
+  });
+
+  test("field should be touched after focus", () => {
+    form.find("input").prop("onFocus")();
+    form.update();
+    expect(form.state().fields[0].touched).toBe(true);
+  });
+
+  test("field should not be touched after form value update", () => {
+    form.setProps({ value: formValue2 });
+    form.update();
+    expect(form.state().fields[0].touched).toBe(false);
+  });
+});

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -242,7 +242,7 @@ export type EvaluateAllRules = (
   defaultResult: boolean
 ) => boolean;
 
-export type ProcessFields = (FieldDef[], boolean) => FieldDef[];
+export type ProcessFields = (FieldDef[], boolean, boolean) => FieldDef[];
 export type ProcessOptions = (
   FieldDef[],
   OptionsHandler,
@@ -291,8 +291,11 @@ export type DetermineChangedValues = FieldDef => Array<{
   value: Value
 }>;
 
+export type GetTouchedStateForField = (boolean, boolean) => boolean;
+
 export type GetNextStateFromProps = (
   FieldDef[],
+  boolean,
   boolean,
   boolean,
   ?OptionsHandler,

--- a/packages/core/src/types/components.js
+++ b/packages/core/src/types/components.js
@@ -26,6 +26,7 @@ export type FormComponentProps = {
 
 export type FormComponentState = {
   fields: FieldDef[],
+  defaultValue: FormValue,
   value: FormValue,
   isValid: boolean,
   defaultFields: [],

--- a/packages/core/src/utilities/utils.js
+++ b/packages/core/src/utilities/utils.js
@@ -11,6 +11,7 @@ import type {
   FormComponentState,
   GetMissingItems,
   GetNextStateFromProps,
+  GetTouchedStateForField,
   JoinDelimitedValue,
   MapFieldsById,
   OmitFieldValue,
@@ -68,11 +69,12 @@ export const getNextStateFromFields: GetNextStateFromProps = (
   fields,
   showValidationBeforeTouched,
   formIsDisabled,
+  resetTouchedState,
   optionsHandler,
   validationHandler,
   parentContext
 ) => {
-  fields = processFields(fields, !!formIsDisabled);
+  fields = processFields(fields, !!formIsDisabled, resetTouchedState);
   if (optionsHandler) {
     fields = processOptions(fields, optionsHandler, parentContext);
   }
@@ -179,7 +181,21 @@ export const evaluateAllRules: EvaluateAllRules = (
   return rulesPass;
 };
 
-export const processFields: ProcessFields = (fields, formIsDisabled) => {
+export const getTouchedStateForField: GetTouchedStateForField = (
+  currentState,
+  resetState
+) => {
+  if (resetState === true) {
+    return false;
+  }
+  return currentState;
+};
+
+export const processFields: ProcessFields = (
+  fields,
+  formIsDisabled,
+  resetTouchedState = false
+) => {
   const fieldsById = mapFieldsById(fields);
   const updatedFields = fields.map(field => {
     const {
@@ -199,7 +215,7 @@ export const processFields: ProcessFields = (fields, formIsDisabled) => {
 
     return {
       ...field,
-      touched,
+      touched: getTouchedStateForField(touched, resetTouchedState),
       value: processedValue,
       visible: evaluateAllRules(visibleWhen, fieldsById, visible !== false),
       required: evaluateAllRules(requiredWhen, fieldsById, !!required),

--- a/packages/core/src/utilities/utils.test.js
+++ b/packages/core/src/utilities/utils.test.js
@@ -8,6 +8,7 @@ import {
   fieldDefIsValid,
   getFirstDefinedValue,
   getMissingItems,
+  getTouchedStateForField,
   joinDelimitedValue,
   mapFieldsById,
   shouldOmitFieldValue,
@@ -239,7 +240,7 @@ describe("processFields", () => {
     shouldBeEnabled
   ];
 
-  const processedFields = processFields(fields, false);
+  const processedFields = processFields(fields, false, false);
   const processedFieldsById = mapFieldsById(processedFields);
 
   test("field should be visible", () => {
@@ -262,7 +263,7 @@ describe("processFields", () => {
   });
 
   test("all fields should be disabled when form is disabled", () => {
-    const processedFields = processFields(fields, true);
+    const processedFields = processFields(fields, true, false);
     const processedFieldsById = mapFieldsById(processedFields);
     expect(processedFieldsById.shouldBeVisible.disabled).toBe(true);
     expect(processedFieldsById.shouldBeHidden.disabled).toBe(true);
@@ -505,19 +506,19 @@ describe("default value handling", () => {
   };
 
   test("default value is assigned to value", () => {
-    const processedFields = processFields([field], false);
+    const processedFields = processFields([field], false, false);
     expect(processedFields[0].value).toEqual("bob");
   });
 
   test("Value takes precedence over defaultValue", () => {
     field.value = "ted";
-    const processedFields = processFields([field], false);
+    const processedFields = processFields([field], false, false);
     expect(processedFields[0].value).toEqual("ted");
   });
 
   test("Falsy value takes precedence over defaultValue", () => {
     field.value = false;
-    const processedFields = processFields([field], false);
+    const processedFields = processFields([field], false, false);
     expect(processedFields[0].value).toEqual(false);
   });
 });
@@ -533,7 +534,7 @@ describe("trimming behaviour", () => {
   };
 
   test("leading and trailing whitespace is NOT removed from when processed", () => {
-    const processedFields = processFields([field], false);
+    const processedFields = processFields([field], false, false);
     const trimmedField = processedFields[0];
     expect(trimmedField.value).toEqual(value);
   });
@@ -592,5 +593,20 @@ describe("setOptionsInFieldInState", () => {
 
   test("assigns pending options as undefined", () => {
     expect(updatedState.fields[1].pendingOptions).toBeUndefined();
+  });
+});
+
+describe("getTouchedStateForField", () => {
+  test("returns false on reset when touched is true", () => {
+    expect(getTouchedStateForField(true, true)).toBe(false);
+  });
+  test("returns false on reset when touched is false", () => {
+    expect(getTouchedStateForField(false, true)).toBe(false);
+  });
+  test("returns false with no reset when touched is false", () => {
+    expect(getTouchedStateForField(false, false)).toBe(false);
+  });
+  test("returns true with no reset when touched is true", () => {
+    expect(getTouchedStateForField(true, false)).toBe(true);
   });
 });


### PR DESCRIPTION
This addresses #22 ...however I think it needs some minor refinement before update because it is causing an issue with the demo page in that the examples are showing immediate validation errors. I think that rather than just comparing value by reference it might be necessary to do a deep comparison of value.

I'm also not completely happy sticking with `value` as the prop for the Form component and wonder if it might be better to switch to `defaultValue` for clarity.