### PR TITLE
Ensure validation messages are not shown immediately

### DIFF
--- a/packages/core/src/comparator.test.js
+++ b/packages/core/src/comparator.test.js
@@ -148,7 +148,7 @@ describe("compare date fields", () => {
     secondDate.prop("onFocus")();
     form.update();
     expect(form.state().fields[0].errorMessages).toBe(
-      "A value must be provided"
+      "A value must be provided, Must be before second date"
     );
     expect(form.state().fields[1].errorMessages).toBe("");
   });

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -344,18 +344,17 @@ export const validateField: ValidateField = (
   let errorMessages = [];
   if (visible) {
     const value = getValueFromField(field);
+    const valueProvided = hasValue(value);
     if (required) {
-      isValid = hasValue(value);
-      if (!isValid) {
+      if (!valueProvided) {
+        isValid = valueProvided;
         const { missingValueMessage = "A value must be provided" } = field;
         errorMessages.push(missingValueMessage);
       }
-    }
-
-    if (!hasValue(value)) {
+    } else if (!valueProvided) {
       // do not run all validations if the field is empty
       return Object.assign({}, field, {
-        isValid,
+        isValid: true,
         isDiscretelyInvalid: !isValid,
         errorMessages: errorMessages.length ? errorMessages.join(", ") : ""
       });

--- a/packages/core/src/utilities/validation.test.js
+++ b/packages/core/src/utilities/validation.test.js
@@ -157,6 +157,53 @@ describe("validateField", () => {
     const validationResult = validateField(testField, [testField], true);
     expect(validationResult.isValid).toBe(true);
   });
+
+  test("field is only discretely invalid if not touched", () => {
+    const testField = {
+      ...field1,
+      visible: true,
+      required: true,
+      value: "",
+      touched: false
+    };
+    const validationResult = validateField(testField, [testField], false);
+    expect(validationResult.isValid).toBe(true);
+    expect(validationResult.isDiscretelyInvalid).toBe(true);
+    expect(validationResult.errorMessages).toBe("");
+  });
+
+  test("field is invalid when touched", () => {
+    const testField = {
+      ...field1,
+      visible: true,
+      required: true,
+      value: "",
+      touched: true
+    };
+    const validationResult = validateField(testField, [testField], false);
+    expect(validationResult.isValid).toBe(false);
+    expect(validationResult.isDiscretelyInvalid).toBe(true);
+    expect(validationResult.errorMessages).toBe("A value must be provided");
+  });
+
+  test("field validation rules not processed without value", () => {
+    const testField = {
+      ...field1,
+      visible: true,
+      required: false,
+      value: "",
+      touched: true,
+      validWhen: {
+        matchesRegEx: {
+          pattern: "^[\\d]+$",
+          message: "Length can only be in whole numbers"
+        }
+      }
+    };
+    const validationResult = validateField(testField, [testField], true);
+    expect(validationResult.isValid).toBe(true);
+    expect(validationResult.isDiscretelyInvalid).toBe(false);
+  });
 });
 
 describe("lengthIsGreaterThan validator", () => {


### PR DESCRIPTION
This PR addresses an issue where the validation errors were still being shown immediately. I've added some additional tests to prevent future regressions. 