### PR TITLE
add autoFocus property for atlasskit component

### DIFF
--- a/packages/atlaskit/src/components/fields/Date.js
+++ b/packages/atlaskit/src/components/fields/Date.js
@@ -20,7 +20,7 @@ class AtlaskitDate extends React.Component<Field> {
       required,
       value,
       label,
-      autoFocus
+      autofocus
     } = this.props;
     return (
       <AkField
@@ -39,7 +39,7 @@ class AtlaskitDate extends React.Component<Field> {
           value={value}
           isDisabled={disabled}
           onFocus={() => onFieldFocus(id)}
-          autoFocus={autoFocus}
+          autoFocus={autofocus}
         />
       </AkField>
     );

--- a/packages/atlaskit/src/components/fields/FieldText.js
+++ b/packages/atlaskit/src/components/fields/FieldText.js
@@ -20,7 +20,7 @@ class AtlaskitFieldText extends React.Component<Field> {
       required,
       value,
       label,
-      autoFocus
+      autofocus
     } = this.props;
     return (
       <AkField
@@ -39,7 +39,7 @@ class AtlaskitFieldText extends React.Component<Field> {
           onFocus={() => onFieldFocus(id)}
           value={value}
           disabled={disabled}
-          autoFocus={autoFocus}
+          autoFocus={autofocus}
         />
       </AkField>
     );

--- a/packages/atlaskit/src/components/fields/FieldTextArea.js
+++ b/packages/atlaskit/src/components/fields/FieldTextArea.js
@@ -20,7 +20,7 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
       required,
       value,
       label,
-      autoFocus
+      autofocus
     } = this.props;
     return (
       <AkField
@@ -38,7 +38,7 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
           value={value}
           onChange={(evt: any) => onFieldChange(id, evt.target.value)}
           onFocus={() => onFieldFocus(id)}
-          autoFocus={autoFocus}
+          autoFocus={autofocus}
         />
       </AkField>
     );

--- a/packages/atlaskit/src/components/fields/MultiSelect.js
+++ b/packages/atlaskit/src/components/fields/MultiSelect.js
@@ -24,7 +24,7 @@ class AtlaskitSelect extends React.Component<Field> {
       touched,
       validWhen,
       requiredWhen,
-      autoFocus
+      autofocus
     } = this.props;
     const defaultValue = [];
     const stringValue: string | void = value ? value.toString() : undefined;
@@ -91,7 +91,7 @@ class AtlaskitSelect extends React.Component<Field> {
             onFieldChange(id, value.map(item => item.value));
           }}
           onFocus={() => onFieldFocus(id)}
-          autoFocus={autoFocus}
+          autoFocus={autofocus}
         />
       </AkField>
     );

--- a/packages/atlaskit/src/components/fields/Select.js
+++ b/packages/atlaskit/src/components/fields/Select.js
@@ -24,7 +24,7 @@ class AtlaskitSelect extends React.Component<Field> {
       touched,
       validWhen,
       requiredWhen,
-      autoFocus
+      autofocus
     } = this.props;
     let defaultSelected;
     const stringValue: string | void = value ? value.toString() : undefined;
@@ -85,7 +85,7 @@ class AtlaskitSelect extends React.Component<Field> {
             }
           }}
           onFocus={() => onFieldFocus(id)}
-          autoFocus={autoFocus}
+          autoFocus={autofocus}
         />
       </AkField>
     );

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -213,7 +213,7 @@ export type FieldDef = {
   },
   trimValue?: boolean,
   touched?: boolean, // TODO: Should this actually be on field?
-  autoFocus?: boolean,
+  autofocus?: boolean
 };
 
 export type Field = FieldDef & {


### PR DESCRIPTION
Usually, the form is focussed on the first field, but if we have some other input element before the form 
the focus will be applied to this element and we need to have a possibility to set focus to desired fields
I'm adding property autoFocus only to those fields which support it.
In case if we pass autoFocus to the multiple fields the focus will be set to the last element