### PR TITLE
mark field as touched in onFieldChange event handler

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -156,6 +156,7 @@ export default class Form extends Component<
       disabled = false
     } = this.props;
     let { fields } = this.state;
+    fields = updateFieldTouchedState(id, true, fields);
     fields = updateFieldValue(id, value, fields);
     const nextState = getNextStateFromFields(
       fields,
@@ -191,7 +192,6 @@ export default class Form extends Component<
       disabled = false
     } = this.props;
     let { fields } = this.state;
-    fields = updateFieldTouchedState(id, true, fields);
     const nextState = getNextStateFromFields(
       fields,
       showValidationBeforeTouched,


### PR DESCRIPTION
 When we set autofocus to required field the field became invalid, even if flag `showValidationBeforeTouched=false`. I would suggest moving `updateFieldTouchedState` method to the `onFieldChange` event handler instead of `onFieldFocus`.
There is an example of how it works after changes
![mark field as touched onchange](https://user-images.githubusercontent.com/12481114/50399306-33a5e400-0787-11e9-83bb-18d3c52b334e.gif)
