### PR TITLE
Support refreshing options

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -127,15 +127,15 @@ export default class Form extends Component<
       // changes...
       const resetTouchedState = defaultValueChange;
 
-      const nextState = getNextStateFromFields(
+      const nextState = getNextStateFromFields({
         fields,
         showValidationBeforeTouched,
-        disabled,
+        formIsDisabled: disabled,
         resetTouchedState,
         optionsHandler,
         validationHandler,
         parentContext
-      );
+      });
       return {
         ...nextState,
         defaultFields: defaultFieldsFromProps,
@@ -157,15 +157,16 @@ export default class Form extends Component<
     } = this.props;
     let { fields } = this.state;
     fields = updateFieldValue(id, value, fields);
-    const nextState = getNextStateFromFields(
+    const nextState = getNextStateFromFields({
       fields,
+      lastFieldUpdated: id,
       showValidationBeforeTouched,
-      disabled,
-      false,
+      formIsDisabled: disabled,
+      resetTouchedState: false,
       optionsHandler,
       validationHandler,
       parentContext
-    );
+    });
 
     this.setState(
       (state, props) => {
@@ -192,15 +193,15 @@ export default class Form extends Component<
     } = this.props;
     let { fields } = this.state;
     fields = updateFieldTouchedState(id, true, fields);
-    const nextState = getNextStateFromFields(
+    const nextState = getNextStateFromFields({
       fields,
       showValidationBeforeTouched,
-      disabled,
-      false,
+      formIsDisabled: disabled,
+      resetTouchedState: false,
       optionsHandler,
       validationHandler,
       parentContext
-    );
+    });
 
     this.setState(nextState, () => onFieldFocusProp && onFieldFocusProp(id));
   }
@@ -219,20 +220,21 @@ export default class Form extends Component<
     } else {
       fields = registerField(field, fields, value);
       this.setState((state, props) => {
+        const { optionsHandler, validationHandler, parentContext } = props;
         const filteredFields = state.fields.filter(
           existingField => existingField.id !== field.id
         );
         // let updatedFields = fields.concat(filteredFields);
         let updatedFields = filteredFields.concat(field);
-        const nextState = getNextStateFromFields(
-          updatedFields,
+        const nextState = getNextStateFromFields({
+          fields: updatedFields,
           showValidationBeforeTouched,
-          disabled,
-          false,
-          props.optionsHandler,
-          props.validationHandler,
-          props.parentContext
-        );
+          formIsDisabled: disabled,
+          resetTouchedState: false,
+          optionsHandler,
+          validationHandler,
+          parentContext
+        });
         return {
           ...nextState
         };

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -205,6 +205,7 @@ export type FieldDef = {
   addedSuffix?: string,
   removedSuffix?: string,
   options?: Options,
+  refreshOptionsOnChangesTo?: string[],
   pendingOptions?: Promise<Options>,
   misc?: {
     [string]: any
@@ -244,11 +245,18 @@ export type EvaluateAllRules = (
 ) => boolean;
 
 export type ProcessFields = (FieldDef[], boolean, boolean) => FieldDef[];
-export type ProcessOptions = (
-  FieldDef[],
-  OptionsHandler,
-  ?FormContextData
-) => FieldDef[];
+
+export type ShouldOptionsBeRefreshed = ({
+  lastFieldUpdated?: string,
+  field: FieldDef
+}) => boolean;
+
+export type ProcessOptions = ({
+  fields: FieldDef[],
+  lastFieldUpdated?: string,
+  optionsHandler: OptionsHandler,
+  parentContext: ?FormContextData
+}) => FieldDef[];
 
 export type ValidationResult = {
   isValid: boolean,
@@ -294,15 +302,16 @@ export type DetermineChangedValues = FieldDef => Array<{
 
 export type GetTouchedStateForField = (boolean, boolean) => boolean;
 
-export type GetNextStateFromProps = (
-  FieldDef[],
-  boolean,
-  boolean,
-  boolean,
-  ?OptionsHandler,
-  ?ValidationHandler,
-  ?FormContextData
-) => $Shape<FormComponentState>;
+export type GetNextStateFromProps = ({
+  fields: FieldDef[],
+  lastFieldUpdated?: string,
+  showValidationBeforeTouched: boolean,
+  formIsDisabled: boolean,
+  resetTouchedState: boolean,
+  optionsHandler: ?OptionsHandler,
+  validationHandler: ?ValidationHandler,
+  parentContext: ?FormContextData
+}) => $Shape<FormComponentState>;
 
 export type CalculateFormValue = (FieldDef[]) => FormValue;
 

--- a/packages/core/src/utilities/options-handling.test.js
+++ b/packages/core/src/utilities/options-handling.test.js
@@ -1,0 +1,143 @@
+// @flow
+import React from "react";
+import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16.3";
+import chai from "chai";
+import chaiEnzyme from "chai-enzyme";
+import { shouldOptionsBeRefreshed } from "./utils";
+import Form from "../components/Form";
+import FormFragment from "../components/FormFragment";
+import FormContext from "../components/FormContext";
+import FormButton from "../components/Button";
+import type { FieldDef, OptionsHandler, Options } from "../types";
+
+chai.use(chaiEnzyme());
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("shouldOptionsBeRefreshed", () => {
+  const optionsShouldNotRefresh: FieldDef = {
+    id: "OPTIONS_SHOULD_NOT_CHANGE",
+    name: "a",
+    type: "select",
+    options: [
+      {
+        items: ["1"]
+      }
+    ]
+  };
+
+  const optionsShouldBeRefreshed: FieldDef = {
+    id: "OPTIONS_SHOULD_REFRESH",
+    name: "c",
+    type: "select",
+    options: [
+      {
+        items: ["1"]
+      }
+    ],
+    refreshOptionsOnChangesTo: ["FAKE", "TRIGGER", "COUNTERFEIT"]
+  };
+
+  test("options should not be refreshed unless requested", () => {
+    expect(
+      shouldOptionsBeRefreshed({
+        lastFieldUpdated: "TRIGGER",
+        field: optionsShouldNotRefresh
+      })
+    ).toBe(false);
+  });
+
+  test("options should not be refreshed unless last field change is trigger", () => {
+    expect(
+      shouldOptionsBeRefreshed({
+        lastFieldUpdated: "NOPE",
+        field: optionsShouldBeRefreshed
+      })
+    ).toBe(false);
+  });
+
+  test("options should refrehs when last field changed is a trigger", () => {
+    expect(
+      shouldOptionsBeRefreshed({
+        lastFieldUpdated: "TRIGGER",
+        field: optionsShouldBeRefreshed
+      })
+    ).toBe(true);
+  });
+
+  test("returns false when last field changed is undefined", () => {
+    expect(
+      shouldOptionsBeRefreshed({
+        field: optionsShouldBeRefreshed
+      })
+    ).toBe(false);
+  });
+});
+
+describe("options handler", () => {
+  const onFormChange = jest.fn();
+  const singleField: FieldDef[] = [
+    {
+      id: "FIELD1",
+      name: "prop1",
+      type: "text",
+      defaultValue: "test"
+    },
+    {
+      id: "FIELD2",
+      name: "prop2",
+      type: "select",
+      refreshOptionsOnChangesTo: ["FIELD1"]
+    },
+    {
+      id: "FIELD3",
+      name: "prop3",
+      type: "text",
+      defaultValue: "test"
+    }
+  ];
+
+  const optionsHandler: OptionsHandler = jest.fn(
+    (fieldId, fields, parentContext) => {
+      const options: Options = [
+        {
+          items: [
+            {
+              label: "A",
+              value: "1"
+            },
+            {
+              label: "B",
+              value: "2"
+            }
+          ]
+        }
+      ];
+      return options;
+    }
+  );
+
+  const form = mount(
+    <Form
+      defaultFields={singleField}
+      onChange={onFormChange}
+      optionsHandler={optionsHandler}
+    />
+  );
+
+  test("options handler is called initially for each field", () => {
+    expect(optionsHandler.mock.calls.length).toBe(3); // Called for each field
+  });
+
+  test("options handler is called again when trigger field is updated", () => {
+    const inputField = form.find("input[type='text']").at(0);
+    inputField.prop("onChange")({ target: { value: "updated" } });
+    expect(optionsHandler.mock.calls.length).toBe(4);
+  });
+
+  test("options handler is NOT called again if a different field is changed", () => {
+    const inputField = form.find("input[type='text']").at(1);
+    inputField.prop("onChange")({ target: { value: "updated" } });
+    expect(optionsHandler.mock.calls.length).toBe(4);
+  });
+});

--- a/packages/core/src/utilities/utils.js
+++ b/packages/core/src/utilities/utils.js
@@ -20,6 +20,7 @@ import type {
   ProcessOptions,
   RegisterField,
   RegisterFields,
+  ShouldOptionsBeRefreshed,
   SplitDelimitedValue,
   UpdateFieldTouchedState,
   UpdateFieldValue,
@@ -58,18 +59,24 @@ export const registerFields: RegisterFields = (fieldsToValidate, formValue) => {
   return fields;
 };
 
-export const getNextStateFromFields: GetNextStateFromProps = (
+export const getNextStateFromFields: GetNextStateFromProps = ({
   fields,
+  lastFieldUpdated,
   showValidationBeforeTouched,
   formIsDisabled,
   resetTouchedState,
   optionsHandler,
   validationHandler,
   parentContext
-) => {
+}) => {
   fields = processFields(fields, !!formIsDisabled, resetTouchedState);
   if (optionsHandler) {
-    fields = processOptions(fields, optionsHandler, parentContext);
+    fields = processOptions({
+      fields,
+      lastFieldUpdated,
+      optionsHandler,
+      parentContext
+    });
   }
 
   fields = validateAllFields(
@@ -220,14 +227,27 @@ export const processFields: ProcessFields = (
   return updatedFields;
 };
 
-export const processOptions: ProcessOptions = (
+export const shouldOptionsBeRefreshed: ShouldOptionsBeRefreshed = ({
+  lastFieldUpdated,
+  field
+}) => {
+  const { refreshOptionsOnChangesTo } = field;
+  if (lastFieldUpdated && refreshOptionsOnChangesTo) {
+    return refreshOptionsOnChangesTo.indexOf(lastFieldUpdated) !== -1;
+  }
+
+  return false;
+};
+
+export const processOptions: ProcessOptions = ({
   fields,
+  lastFieldUpdated,
   optionsHandler,
   parentContext
-) => {
+}) => {
   return fields.map(field => {
     const { id, options } = field;
-    if (!options) {
+    if (!options || shouldOptionsBeRefreshed({ lastFieldUpdated, field })) {
       const handlerOptions = optionsHandler(id, fields, parentContext);
       if (handlerOptions instanceof Promise) {
         field.options = [];


### PR DESCRIPTION
This PR addresses #39 by adding a new attribute to fields called `refreshOptionsOnChangesTo` that is an array of the fields that should trigger a refresh of the options for that field.

I've refactored some of the code to start passing objects to functions so that it is clearer what data is being passed (this is a pattern I used to use and I think it is going to prove useful here for increased clarity - especially when we have argument signatures with lots of booleans).

I've added unit tests to verify that a fields options are updated when a triggering field is changed.