### PR TITLE
Show validation warnings on blur

### DIFF
--- a/packages/atlaskit/src/components/fields/Checkbox.js
+++ b/packages/atlaskit/src/components/fields/Checkbox.js
@@ -16,6 +16,7 @@ class AtlaskitCheckbox extends React.Component<Field> {
       name,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       value,
       label,
       required
@@ -38,6 +39,7 @@ class AtlaskitCheckbox extends React.Component<Field> {
           initiallyChecked={value}
           onChange={evt => onFieldChange(id, evt.isChecked)}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
         />
       </AkField>
     );

--- a/packages/atlaskit/src/components/fields/Date.js
+++ b/packages/atlaskit/src/components/fields/Date.js
@@ -16,6 +16,7 @@ class AtlaskitDate extends React.Component<Field> {
       name,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       placeholder,
       required,
       value,
@@ -39,6 +40,7 @@ class AtlaskitDate extends React.Component<Field> {
           value={value}
           isDisabled={disabled}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
           autoFocus={autofocus}
         />
       </AkField>

--- a/packages/atlaskit/src/components/fields/FieldText.js
+++ b/packages/atlaskit/src/components/fields/FieldText.js
@@ -16,6 +16,7 @@ class AtlaskitFieldText extends React.Component<Field> {
       name,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       placeholder,
       required,
       value,
@@ -37,6 +38,7 @@ class AtlaskitFieldText extends React.Component<Field> {
           placeholder={placeholder}
           onChange={(evt: any) => onFieldChange(id, evt.target.value)}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
           value={value}
           disabled={disabled}
           autoFocus={autofocus}

--- a/packages/atlaskit/src/components/fields/FieldText.js
+++ b/packages/atlaskit/src/components/fields/FieldText.js
@@ -38,7 +38,10 @@ class AtlaskitFieldText extends React.Component<Field> {
           placeholder={placeholder}
           onChange={(evt: any) => onFieldChange(id, evt.target.value)}
           onFocus={() => onFieldFocus(id)}
-          onBlur={() => onFieldBlur(id)}
+          onBlur={() => {
+            console.log("Field has been blurred");
+            onFieldBlur(id);
+          }}
           value={value}
           disabled={disabled}
           autoFocus={autofocus}

--- a/packages/atlaskit/src/components/fields/FieldTextArea.js
+++ b/packages/atlaskit/src/components/fields/FieldTextArea.js
@@ -16,6 +16,7 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
       name,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       placeholder,
       required,
       value,
@@ -38,6 +39,7 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
           value={value}
           onChange={(evt: any) => onFieldChange(id, evt.target.value)}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
           autoFocus={autofocus}
         />
       </AkField>

--- a/packages/atlaskit/src/components/fields/MultiSelect.js
+++ b/packages/atlaskit/src/components/fields/MultiSelect.js
@@ -21,6 +21,7 @@ class AtlaskitSelect extends React.Component<Field> {
       label,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       touched,
       validWhen,
       requiredWhen,
@@ -91,6 +92,7 @@ class AtlaskitSelect extends React.Component<Field> {
             onFieldChange(id, value.map(item => item.value));
           }}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
           autoFocus={autofocus}
         />
       </AkField>

--- a/packages/atlaskit/src/components/fields/RadioGroup.js
+++ b/packages/atlaskit/src/components/fields/RadioGroup.js
@@ -28,6 +28,7 @@ class AtlaskitRadioGroup extends React.Component<Field> {
       value,
       label,
       onFieldFocus,
+      onFieldBlur,
       onFieldChange
     } = this.props;
     const stringValue: string | void = value ? value.toString() : undefined;
@@ -75,6 +76,7 @@ class AtlaskitRadioGroup extends React.Component<Field> {
             items={items}
             onRadioChange={(evt: any) => onFieldChange(id, evt.target.value)}
             onFocus={() => onFieldFocus(id)}
+            onBlur={() => onFieldBlur(id)}
           />
         </Layout>
       </AkField>

--- a/packages/atlaskit/src/components/fields/Select.js
+++ b/packages/atlaskit/src/components/fields/Select.js
@@ -21,6 +21,7 @@ class AtlaskitSelect extends React.Component<Field> {
       label,
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       touched,
       validWhen,
       requiredWhen,
@@ -85,6 +86,7 @@ class AtlaskitSelect extends React.Component<Field> {
             }
           }}
           onFocus={() => onFieldFocus(id)}
+          onBlur={() => onFieldBlur(id)}
           autoFocus={autofocus}
         />
       </AkField>

--- a/packages/atlaskit/src/renderer.js
+++ b/packages/atlaskit/src/renderer.js
@@ -9,7 +9,12 @@ import Select from "./components/fields/Select";
 import MultiSelect from "./components/fields/MultiSelect";
 import type { FieldRenderer } from "react-forms-processor";
 
-const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
+const renderer: FieldRenderer = (
+  field,
+  onChange,
+  onFieldFocus,
+  onFieldBlur
+) => {
   const { id, type, label } = field;
   switch (type) {
     case "text":

--- a/packages/core/src/comparator.test.js
+++ b/packages/core/src/comparator.test.js
@@ -20,7 +20,12 @@ chai.use(chaiEnzyme());
 Enzyme.configure({ adapter: new Adapter() });
 
 // We want to create a custom renderer that takes numbers as input values but displays them as strings...
-const customRenderer: FieldRenderer = (field, onChange, onFieldFocus) => {
+const customRenderer: FieldRenderer = (
+  field,
+  onChange,
+  onFieldFocus,
+  onFieldBlur
+) => {
   const {
     disabled = false,
     errorMessages,
@@ -51,6 +56,7 @@ const customRenderer: FieldRenderer = (field, onChange, onFieldFocus) => {
             required={required}
             onChange={evt => onChange(id, new Date(evt.target.value).getTime())}
             onFocus={() => onFieldFocus(id)}
+            onBlur={() => onFieldBlur(id)}
           />
           {!isValid ? (
             <span className="errors">{errorMessages}</span>
@@ -61,7 +67,7 @@ const customRenderer: FieldRenderer = (field, onChange, onFieldFocus) => {
       );
     }
     default: {
-      return nativeRenderer(field, onChange, onFieldFocus);
+      return nativeRenderer(field, onChange, onFieldFocus, onFieldBlur);
     }
   }
 };

--- a/packages/core/src/comparator.test.js
+++ b/packages/core/src/comparator.test.js
@@ -150,8 +150,8 @@ describe("compare date fields", () => {
   test("form is initially invalid because no dates are set", () => {
     expect(form.state().isValid).toBe(false);
 
-    firstDate.prop("onFocus")();
-    secondDate.prop("onFocus")();
+    firstDate.prop("onBlur")();
+    secondDate.prop("onBlur")();
     form.update();
     expect(form.state().fields[0].errorMessages).toBe(
       "A value must be provided, Must be before second date"

--- a/packages/core/src/components/FieldWrapper.js
+++ b/packages/core/src/components/FieldWrapper.js
@@ -8,9 +8,7 @@ import type {
 } from "../types";
 import "./FieldWrapper.css";
 
-class FieldWrapper extends React.Component<
-  FieldWrapperComponentWithContextProps
-> {
+class FieldWrapper extends React.Component<FieldWrapperComponentWithContextProps> {
   constructor(props: FieldWrapperComponentWithContextProps) {
     super(props);
     const { registerField, onFieldChange, ...fieldDef } = props;
@@ -37,6 +35,7 @@ class FieldWrapper extends React.Component<
         parentContext: pc1,
         onFieldChange: ofc1,
         onFieldFocus: off1,
+        onFieldBlur: ofb1,
         options: o1,
         registerField: rf1,
         fields: f1,
@@ -48,6 +47,7 @@ class FieldWrapper extends React.Component<
         parentContext: pc2,
         onFieldChange: ofc2,
         onFieldFocus: off2,
+        onFieldBlur: ofb2,
         options: o2,
         registerField: rf2,
         fields: f2,
@@ -69,6 +69,7 @@ class FieldWrapper extends React.Component<
       fields = [],
       onFieldChange,
       onFieldFocus,
+      onFieldBlur,
       children
     } = this.props;
     const fieldToRender = fields.find(field => field.id === id);
@@ -77,6 +78,7 @@ class FieldWrapper extends React.Component<
         React.cloneElement(child, {
           onFieldChange,
           onFieldFocus,
+          onFieldBlur,
           ...fieldToRender
         })
       );

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -108,8 +108,7 @@ export default class Form extends Component<
         optionsHandler,
         validationHandler,
         parentContext,
-        showValidationBeforeTouched = false,
-        showValidationOnBlur = true
+        showValidationBeforeTouched = false
       } = nextProps;
 
       // If a new value has been passed to the Form as a prop then it should take precedence over the last calculated state
@@ -131,7 +130,6 @@ export default class Form extends Component<
       const nextState = getNextStateFromFields({
         fields,
         showValidationBeforeTouched,
-        showValidationOnBlur,
         formIsDisabled: disabled,
         resetTouchedState,
         optionsHandler,
@@ -155,16 +153,15 @@ export default class Form extends Component<
       validationHandler,
       parentContext,
       showValidationBeforeTouched = false,
-      showValidationOnBlur = true,
       disabled = false
     } = this.props;
     let { fields } = this.state;
+    fields = updateFieldTouchedState(id, true, fields);
     fields = updateFieldValue(id, value, fields);
     const nextState = getNextStateFromFields({
       fields,
       lastFieldUpdated: id,
       showValidationBeforeTouched,
-      showValidationOnBlur,
       formIsDisabled: disabled,
       resetTouchedState: false,
       optionsHandler,
@@ -187,13 +184,22 @@ export default class Form extends Component<
   }
 
   onFieldFocus(id: string) {
+    // At one stage the plan was to only show validation error messages once a field
+    // had been touched, but in reality we only want to show validation messages when
+    // a field has been changed OR has been blurred.
+    // So now we just want to make sure that callbacks on the form for handling when
+    // a field is focused are called.
+    const { onFieldFocus: onFieldFocusProp } = this.props;
+    onFieldFocusProp && onFieldFocusProp(id);
+  }
+
+  onFieldBlur(id: string) {
     const {
       optionsHandler,
       validationHandler,
-      onFieldFocus: onFieldFocusProp,
+      onFieldBlur: onFieldBlurProp,
       parentContext,
       showValidationBeforeTouched = false,
-      showValidationOnBlur = true,
       disabled = false
     } = this.props;
     let { fields } = this.state;
@@ -201,7 +207,6 @@ export default class Form extends Component<
     const nextState = getNextStateFromFields({
       fields,
       showValidationBeforeTouched,
-      showValidationOnBlur,
       formIsDisabled: disabled,
       resetTouchedState: false,
       optionsHandler,
@@ -209,11 +214,7 @@ export default class Form extends Component<
       parentContext
     });
 
-    this.setState(nextState, () => onFieldFocusProp && onFieldFocusProp(id));
-  }
-
-  onFieldBlur(id: string) {
-    // TODO: Set the touched state depending on the field configuration...
+    this.setState(nextState, () => onFieldBlurProp && onFieldBlurProp(id));
   }
 
   // Register field is provided in the context to allow children to register with this form...
@@ -221,7 +222,6 @@ export default class Form extends Component<
     let { fields = [], value = {} } = this.state;
     const {
       showValidationBeforeTouched = false,
-      showValidationOnBlur = true,
       disabled = false
     } = this.props;
 
@@ -240,7 +240,6 @@ export default class Form extends Component<
         const nextState = getNextStateFromFields({
           fields: updatedFields,
           showValidationBeforeTouched,
-          showValidationOnBlur,
           formIsDisabled: disabled,
           resetTouchedState: false,
           optionsHandler,
@@ -262,7 +261,6 @@ export default class Form extends Component<
       validationHandler,
       parentContext,
       showValidationBeforeTouched = false,
-      showValidationOnBlur = true,
       conditionalUpdate = false,
       disabled = false
     } = this.props;
@@ -283,7 +281,6 @@ export default class Form extends Component<
       onFieldFocus,
       parentContext,
       showValidationBeforeTouched,
-      showValidationOnBlur,
       validationHandler,
       conditionalUpdate,
       disabled

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -108,7 +108,8 @@ export default class Form extends Component<
         optionsHandler,
         validationHandler,
         parentContext,
-        showValidationBeforeTouched = false
+        showValidationBeforeTouched = false,
+        showValidationOnBlur = true
       } = nextProps;
 
       // If a new value has been passed to the Form as a prop then it should take precedence over the last calculated state
@@ -130,6 +131,7 @@ export default class Form extends Component<
       const nextState = getNextStateFromFields({
         fields,
         showValidationBeforeTouched,
+        showValidationOnBlur,
         formIsDisabled: disabled,
         resetTouchedState,
         optionsHandler,
@@ -153,6 +155,7 @@ export default class Form extends Component<
       validationHandler,
       parentContext,
       showValidationBeforeTouched = false,
+      showValidationOnBlur = true,
       disabled = false
     } = this.props;
     let { fields } = this.state;
@@ -161,6 +164,7 @@ export default class Form extends Component<
       fields,
       lastFieldUpdated: id,
       showValidationBeforeTouched,
+      showValidationOnBlur,
       formIsDisabled: disabled,
       resetTouchedState: false,
       optionsHandler,
@@ -189,6 +193,7 @@ export default class Form extends Component<
       onFieldFocus: onFieldFocusProp,
       parentContext,
       showValidationBeforeTouched = false,
+      showValidationOnBlur = true,
       disabled = false
     } = this.props;
     let { fields } = this.state;
@@ -196,6 +201,7 @@ export default class Form extends Component<
     const nextState = getNextStateFromFields({
       fields,
       showValidationBeforeTouched,
+      showValidationOnBlur,
       formIsDisabled: disabled,
       resetTouchedState: false,
       optionsHandler,
@@ -206,11 +212,16 @@ export default class Form extends Component<
     this.setState(nextState, () => onFieldFocusProp && onFieldFocusProp(id));
   }
 
+  onFieldBlur(id: string) {
+    // TODO: Set the touched state depending on the field configuration...
+  }
+
   // Register field is provided in the context to allow children to register with this form...
   registerField(field: FieldDef) {
     let { fields = [], value = {} } = this.state;
     const {
       showValidationBeforeTouched = false,
+      showValidationOnBlur = true,
       disabled = false
     } = this.props;
 
@@ -229,6 +240,7 @@ export default class Form extends Component<
         const nextState = getNextStateFromFields({
           fields: updatedFields,
           showValidationBeforeTouched,
+          showValidationOnBlur,
           formIsDisabled: disabled,
           resetTouchedState: false,
           optionsHandler,
@@ -250,11 +262,13 @@ export default class Form extends Component<
       validationHandler,
       parentContext,
       showValidationBeforeTouched = false,
+      showValidationOnBlur = true,
       conditionalUpdate = false,
       disabled = false
     } = this.props;
     const onFieldChange = this.onFieldChange.bind(this); // TODO: Is this creating a new function each time? Does this result in too many listeners?
     const onFieldFocus = this.onFieldFocus.bind(this); // TODO: See above comment
+    const onFieldBlur = this.onFieldBlur.bind(this);
 
     const context: FormContextData = {
       fields,
@@ -264,10 +278,12 @@ export default class Form extends Component<
       renderer,
       optionsHandler,
       options: {},
+      onFieldBlur,
       onFieldChange,
       onFieldFocus,
       parentContext,
       showValidationBeforeTouched,
+      showValidationOnBlur,
       validationHandler,
       conditionalUpdate,
       disabled

--- a/packages/core/src/components/Form.test.js
+++ b/packages/core/src/components/Form.test.js
@@ -146,8 +146,13 @@ describe("validation warnings", () => {
       expect(form.find("span.errors").length).toBe(0);
     });
 
-    test("field should be touched after focus", () => {
+    test("field should NOT be touched after focus", () => {
       form.find("input").prop("onFocus")();
+      expect(form.state().fields[0].touched).toBe(false);
+    });
+
+    test("field should be touched after blur", () => {
+      form.find("input").prop("onBlur")();
       expect(form.state().fields[0].touched).toBe(true);
     });
 
@@ -203,8 +208,14 @@ describe("changing form value prop", () => {
     expect(form.state().fields[0].touched).toBe(false);
   });
 
-  test("field should be touched after focus", () => {
+  test("field should NOT be touched after focus", () => {
     form.find("input").prop("onFocus")();
+    form.update();
+    expect(form.state().fields[0].touched).toBe(false);
+  });
+
+  test("field should be touched after blur", () => {
+    form.find("input").prop("onBlur")();
     form.update();
     expect(form.state().fields[0].touched).toBe(true);
   });

--- a/packages/core/src/components/FormFragment.js
+++ b/packages/core/src/components/FormFragment.js
@@ -57,13 +57,14 @@ const renderFieldIfVisible = (
     fields,
     onFieldChange,
     onFieldFocus,
+    onFieldBlur,
     renderer,
     value
   } = props;
   const fieldToRender = findRegisteredField(fields, field.id);
   if (fieldToRender && fieldToRender.visible) {
     setFieldValue(fieldToRender, field, value);
-    return renderer(fieldToRender, onFieldChange, onFieldFocus);
+    return renderer(fieldToRender, onFieldChange, onFieldFocus, onFieldBlur);
   }
   return null;
 };

--- a/packages/core/src/renderer.js
+++ b/packages/core/src/renderer.js
@@ -5,6 +5,7 @@ import type {
   FieldDef,
   OnFieldChange,
   OnFieldFocus,
+  OnFieldBlur,
   Option
 } from "./types";
 
@@ -29,6 +30,7 @@ const renderSelect = (
   field: FieldDef,
   onChange: OnFieldChange,
   onFieldFocus: OnFieldFocus,
+  onFieldBlur: OnFieldBlur,
   multiple: boolean
 ) => {
   const {
@@ -77,6 +79,7 @@ const renderSelect = (
         disabled={disabled}
         required={required}
         onFocus={() => onFieldFocus(id)}
+        onBlur={() => onFieldBlur(id)}
         onChange={evt => {
           if (multiple) {
             const options = evt.target.options;
@@ -95,7 +98,12 @@ const renderSelect = (
   );
 };
 
-const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
+const renderer: FieldRenderer = (
+  field,
+  onChange,
+  onFieldFocus,
+  onFieldBlur
+) => {
   const {
     disabled = false,
     errorMessages,
@@ -126,14 +134,15 @@ const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
             checked={value}
             onChange={evt => onChange(id, evt.target.checked)}
             onFocus={() => onFieldFocus(id)}
+            onFieldBlur={() => onFieldBlur(id)}
           />
         </div>
       );
     case "select":
-      return renderSelect(field, onChange, onFieldFocus, false);
+      return renderSelect(field, onChange, onFieldFocus, onFieldBlur, false);
 
     case "multiselect":
-      return renderSelect(field, onChange, onFieldFocus, true);
+      return renderSelect(field, onChange, onFieldFocus, onFieldBlur, true);
 
     case "radiogroup":
       items = options.reduce((itemsSoFar, option) => {
@@ -151,6 +160,7 @@ const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
                     checked={item === value}
                     onChange={evt => onChange(id, evt.target.value)}
                     onFocus={() => onFieldFocus(id)}
+                    onBlur={() => onFieldBlur(id)}
                   />
                   <label htmlFor={inputId}>{item}</label>
                 </div>
@@ -166,6 +176,7 @@ const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
                     checked={item.value === value}
                     onChange={evt => onChange(id, evt.target.value)}
                     onFocus={() => onFieldFocus(id)}
+                    onBlur={() => onFieldBlur(id)}
                   />
                   <label htmlFor={inputId}>{item.label || item.value}</label>
                 </div>
@@ -191,6 +202,7 @@ const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
             checked={checked}
             onChange={evt => onChange(id, evt.target.value)}
             onFocus={() => onFieldFocus(id)}
+            onBlur={() => onFieldBlur(id)}
           />
           {required ? "*" : null}
           {!isValid ? <span className="errors">{errorMessages}</span> : null}

--- a/packages/core/src/renderer.test.js
+++ b/packages/core/src/renderer.test.js
@@ -44,7 +44,11 @@ describe("Basic single field form capabilities", () => {
   ];
 
   const wrapper = mount(
-    <Form defaultFields={singleField} onChange={onFormChange} onFieldFocus={onFieldFocus}>
+    <Form
+      defaultFields={singleField}
+      onChange={onFormChange}
+      onFieldFocus={onFieldFocus}
+    >
       <FormButton onClick={onButtonClick} />
     </Form>
   );

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -219,10 +219,16 @@ export type Field = FieldDef & {
   fields: FieldDef[],
   onFieldChange: OnFieldChange,
   onFieldFocus: OnFieldFocus,
+  onFieldBlur: OnFieldBlur,
   registerField?: FieldDef => void
 };
 
-export type FieldRenderer = (FieldDef, OnFieldChange, OnFieldFocus) => any;
+export type FieldRenderer = (
+  FieldDef,
+  OnFieldChange,
+  OnFieldFocus,
+  OnFieldBlur
+) => any;
 
 export type FormValue = {
   [string]: Value
@@ -231,6 +237,7 @@ export type FormValue = {
 export type OnFormChange = (FormValue, boolean) => void;
 
 export type OnFieldFocus = (fieldId: string) => void;
+export type OnFieldBlur = (fieldId: string) => void;
 
 export type EvaluateRule = (rule?: Rule, targetValue: Value) => boolean;
 
@@ -271,12 +278,13 @@ export type ValidateField = (
   ?FormContextData
 ) => FieldDef;
 
-export type ValidateAllFields = (
-  FieldDef[],
-  boolean,
-  ?ValidationHandler,
-  ?FormContextData
-) => FieldDef[];
+export type ValidateAllFields = ({
+  fields: FieldDef[],
+  showValidationBeforeTouched: boolean,
+  showValidationOnBlur: boolean,
+  validationHandler: ?ValidationHandler,
+  parentContext: ?FormContextData
+}) => FieldDef[];
 
 export type CreateFieldDef = ($Shape<FieldDef>) => FieldDef;
 
@@ -306,6 +314,7 @@ export type GetNextStateFromProps = ({
   fields: FieldDef[],
   lastFieldUpdated?: string,
   showValidationBeforeTouched: boolean,
+  showValidationOnBlur: boolean,
   formIsDisabled: boolean,
   resetTouchedState: boolean,
   optionsHandler: ?OptionsHandler,
@@ -330,8 +339,10 @@ export type FormContextData = {
   renderer: FieldRenderer,
   onFieldChange: OnFieldChange,
   onFieldFocus: OnFieldFocus,
+  onFieldBlur: OnFieldBlur,
   parentContext?: FormContextData,
   showValidationBeforeTouched: boolean,
+  showValidationOnBlur: boolean,
   conditionalUpdate: boolean,
   disabled: boolean
 };

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -281,7 +281,6 @@ export type ValidateField = (
 export type ValidateAllFields = ({
   fields: FieldDef[],
   showValidationBeforeTouched: boolean,
-  showValidationOnBlur: boolean,
   validationHandler: ?ValidationHandler,
   parentContext: ?FormContextData
 }) => FieldDef[];
@@ -314,7 +313,6 @@ export type GetNextStateFromProps = ({
   fields: FieldDef[],
   lastFieldUpdated?: string,
   showValidationBeforeTouched: boolean,
-  showValidationOnBlur: boolean,
   formIsDisabled: boolean,
   resetTouchedState: boolean,
   optionsHandler: ?OptionsHandler,
@@ -342,7 +340,6 @@ export type FormContextData = {
   onFieldBlur: OnFieldBlur,
   parentContext?: FormContextData,
   showValidationBeforeTouched: boolean,
-  showValidationOnBlur: boolean,
   conditionalUpdate: boolean,
   disabled: boolean
 };

--- a/packages/core/src/types/components.js
+++ b/packages/core/src/types/components.js
@@ -6,6 +6,7 @@ import type {
   FormValue,
   OnFormChange,
   OnFieldFocus,
+  OnFieldBlur,
   FieldRenderer,
   OptionsHandler,
   ValidationHandler
@@ -16,6 +17,7 @@ export type FormComponentProps = {
   value?: FormValue,
   onChange?: OnFormChange,
   onFieldFocus?: OnFieldFocus,
+  onFieldBlur?: OnFieldBlur,
   renderer?: FieldRenderer,
   optionsHandler?: OptionsHandler,
   validationHandler?: ValidationHandler,

--- a/packages/core/src/utilities/utils.js
+++ b/packages/core/src/utilities/utils.js
@@ -63,7 +63,6 @@ export const getNextStateFromFields: GetNextStateFromProps = ({
   fields,
   lastFieldUpdated,
   showValidationBeforeTouched,
-  showValidationOnBlur,
   formIsDisabled,
   resetTouchedState,
   optionsHandler,
@@ -83,7 +82,6 @@ export const getNextStateFromFields: GetNextStateFromProps = ({
   fields = validateAllFields({
     fields,
     showValidationBeforeTouched,
-    showValidationOnBlur,
     validationHandler,
     parentContext
   });

--- a/packages/core/src/utilities/utils.js
+++ b/packages/core/src/utilities/utils.js
@@ -63,6 +63,7 @@ export const getNextStateFromFields: GetNextStateFromProps = ({
   fields,
   lastFieldUpdated,
   showValidationBeforeTouched,
+  showValidationOnBlur,
   formIsDisabled,
   resetTouchedState,
   optionsHandler,
@@ -79,12 +80,13 @@ export const getNextStateFromFields: GetNextStateFromProps = ({
     });
   }
 
-  fields = validateAllFields(
+  fields = validateAllFields({
     fields,
     showValidationBeforeTouched,
+    showValidationOnBlur,
     validationHandler,
     parentContext
-  );
+  });
 
   const value = calculateFormValue(fields);
   const isValid = fields.every(field => field.isValid);

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -404,12 +404,13 @@ export const validateField: ValidateField = (
   });
 };
 
-export const validateAllFields: ValidateAllFields = (
+export const validateAllFields: ValidateAllFields = ({
   fields,
   showValidationBeforeTouched,
+  showValidationOnBlur,
   validationHandler,
   parentContext
-) => {
+}) => {
   const validatedFields = fields.map(field =>
     validateField(
       field,

--- a/packages/core/src/utilities/validation.js
+++ b/packages/core/src/utilities/validation.js
@@ -407,7 +407,6 @@ export const validateField: ValidateField = (
 export const validateAllFields: ValidateAllFields = ({
   fields,
   showValidationBeforeTouched,
-  showValidationOnBlur,
   validationHandler,
   parentContext
 }) => {

--- a/packages/formbuilder/src/renderer.js
+++ b/packages/formbuilder/src/renderer.js
@@ -9,7 +9,12 @@ import type {
 } from "react-forms-processor";
 import RepeatingFormField from "./Repeats";
 
-const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
+const renderer: FieldRenderer = (
+  field,
+  onChange,
+  onFieldFocus,
+  onFieldBlur
+) => {
   const { defaultValue = [], id, label, type, misc = {} } = field;
   switch (type) {
     case "field":
@@ -36,7 +41,7 @@ const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
       );
 
     default:
-      return akRenderer(field, onChange, onFieldFocus);
+      return akRenderer(field, onChange, onFieldFocus, onFieldBlur);
   }
 };
 

--- a/packages/material-ui/src/renderer.js
+++ b/packages/material-ui/src/renderer.js
@@ -12,7 +12,12 @@ import type {
   OnFieldChange
 } from "react-forms-processor";
 
-const renderer: FieldRenderer = (field, onChange, onFieldFocus) => {
+const renderer: FieldRenderer = (
+  field,
+  onChange,
+  onFieldFocus,
+  onFieldBlur
+) => {
   const { id, type, label, misc = {} } = field;
   switch (type) {
     case "text":


### PR DESCRIPTION
This PR attempts to switch the behaviour of validation display so that warnings are only shown when a field has been blurred or the value has been changed.

At the time of writing the unit tests are passing and it is working properly for the native HTML renderer but it appears that there are issues with Atlaskit components not firing the necessary onBlur event.