### PR TITLE
Fix description to use helper text

### DIFF
--- a/packages/atlaskit/src/components/fields/Checkbox.js
+++ b/packages/atlaskit/src/components/fields/Checkbox.js
@@ -3,57 +3,60 @@ import React from "react";
 import { Checkbox } from "@atlaskit/checkbox";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 class AtlaskitCheckbox extends React.Component<Field> {
-    render() {
-        const {
-            description,
-            disabled,
-            errorMessages,
-            id,
-            isValid,
-            name,
-            onFieldChange,
-            value,
-            label,
-            required
-        } = this.props;
-        const stringValue: string | void = value ? value.toString() : undefined;
-        return (
-            <AkField
-                name={name}
-                helperText={description}
-                isRequired={required}
-                isInvalid={!isValid}
-                invalidMessage={errorMessages}
-                validateOnBlur={false}
-            >
-                {({ fieldProps }) => (
-                    <React.Fragment>
-                        <Checkbox
-                            {...fieldProps}
-                            label={label}
-                            name={name}
-                            isDisabled={disabled}
-                            value={stringValue}
-                            defaultChecked={stringValue === "true"}
-                            isChecked={stringValue === "true"}
-                            isInvalid={!isValid}
-                            onChange={evt => {
-                                onFieldChange(id, evt.target.checked);
-                            }}
-                        />
-                        {!isValid && <ErrorMessage>{errorMessages}</ErrorMessage>}
-                    </React.Fragment>
-                )}
-            </AkField>
-        );
-    }
+  render() {
+    const {
+      description,
+      disabled,
+      errorMessages,
+      id,
+      isValid,
+      name,
+      onFieldChange,
+      value,
+      label,
+      required
+    } = this.props;
+    const stringValue: string | void = value ? value.toString() : undefined;
+    return (
+      <AkField
+        name={name}
+        isRequired={required}
+        isInvalid={!isValid}
+        invalidMessage={errorMessages}
+        validateOnBlur={false}
+      >
+        {({ fieldProps }) => (
+          <React.Fragment>
+            <Checkbox
+              {...fieldProps}
+              label={label}
+              name={name}
+              isDisabled={disabled}
+              value={stringValue}
+              defaultChecked={stringValue === "true"}
+              isChecked={stringValue === "true"}
+              isInvalid={!isValid}
+              onChange={evt => {
+                onFieldChange(id, evt.target.checked);
+              }}
+            />
+            {!isValid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
+          </React.Fragment>
+        )}
+      </AkField>
+    );
+  }
 }
 
 export default (props: FieldDef) => (
-    <FieldWrapper {...props}>
-        <AtlaskitCheckbox />
-    </FieldWrapper>
+  <FieldWrapper {...props}>
+    <AtlaskitCheckbox />
+  </FieldWrapper>
 );

--- a/packages/atlaskit/src/components/fields/Date.js
+++ b/packages/atlaskit/src/components/fields/Date.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import { DatePicker } from "@atlaskit/datetime-picker";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
 
@@ -27,7 +27,6 @@ class AtlaskitDate extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={!isValid}
         invalidMessage={errorMessages}
@@ -48,7 +47,11 @@ class AtlaskitDate extends React.Component<Field> {
               onBlur={() => onFieldBlur(id)}
               autoFocus={autofocus}
             />
-            {!isValid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+            {!isValid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
           </React.Fragment>
         )}
       </AkField>

--- a/packages/atlaskit/src/components/fields/FieldText.js
+++ b/packages/atlaskit/src/components/fields/FieldText.js
@@ -4,7 +4,7 @@ import FieldText from "@atlaskit/field-text";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
 import styled from "styled-components";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 const Layout = styled.div`
   label {
@@ -34,7 +34,6 @@ class AtlaskitFieldText extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={!isValid}
         invalidMessage={errorMessages}
@@ -61,7 +60,11 @@ class AtlaskitFieldText extends React.Component<Field> {
                   shouldFitContainer={shouldFitContainer}
                 />
               </Layout>
-              {!isValid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+              {!isValid ? (
+                <ErrorMessage>{errorMessages}</ErrorMessage>
+              ) : (
+                <HelperMessage>{description}</HelperMessage>
+              )}
             </React.Fragment>
           );
         }}

--- a/packages/atlaskit/src/components/fields/FieldTextArea.js
+++ b/packages/atlaskit/src/components/fields/FieldTextArea.js
@@ -3,7 +3,7 @@ import React from "react";
 import FieldTextArea from "@atlaskit/field-text-area";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 class AtlaskitFieldTextArea extends React.Component<Field> {
   render() {
@@ -28,7 +28,6 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={!isValid}
         invalidMessage={errorMessages}
@@ -50,7 +49,11 @@ class AtlaskitFieldTextArea extends React.Component<Field> {
               isInvalid={!isValid}
               shouldFitContainer={shouldFitContainer}
             />
-            {!isValid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+            {!isValid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
           </React.Fragment>
         )}
       </AkField>

--- a/packages/atlaskit/src/components/fields/MultiSelect.js
+++ b/packages/atlaskit/src/components/fields/MultiSelect.js
@@ -3,7 +3,7 @@ import React from "react";
 import Select from "@atlaskit/select";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 class AtlaskitSelect extends React.Component<Field> {
   render() {
@@ -77,7 +77,6 @@ class AtlaskitSelect extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={isInvalid}
         invalidMessage={errorMessages}
@@ -104,7 +103,11 @@ class AtlaskitSelect extends React.Component<Field> {
               isInvalid={isInvalid}
               shouldFitContainer={shouldFitContainer}
             />
-            {isInvalid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+            {isInvalid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
           </React.Fragment>
         )}
       </AkField>

--- a/packages/atlaskit/src/components/fields/RadioGroup.js
+++ b/packages/atlaskit/src/components/fields/RadioGroup.js
@@ -4,7 +4,7 @@ import RadioGroup from "@atlaskit/field-radio-group";
 import { FieldWrapper } from "react-forms-processor";
 import styled from "styled-components";
 import type { Field, FieldDef } from "react-forms-processor";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 // NOTE: Temporary hack to workaround the problem of duplicate label appearing - this can stop being used as soon as Atlaskit forms support Radio Groups properly
 const Layout = styled.div`
@@ -63,7 +63,6 @@ class AtlaskitRadioGroup extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={!isValid}
         invalidMessage={errorMessages}
@@ -86,7 +85,11 @@ class AtlaskitRadioGroup extends React.Component<Field> {
                 isInvalid={!isValid}
               />
             </Layout>
-            {!isValid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+            {!isValid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
           </React.Fragment>
         )}
       </AkField>

--- a/packages/atlaskit/src/components/fields/Select.js
+++ b/packages/atlaskit/src/components/fields/Select.js
@@ -3,7 +3,7 @@ import React from "react";
 import Select from "@atlaskit/select";
 import { FieldWrapper } from "react-forms-processor";
 import type { Field, FieldDef } from "react-forms-processor";
-import { Field as AkField, ErrorMessage } from "@atlaskit/form";
+import { Field as AkField, ErrorMessage, HelperMessage } from "@atlaskit/form";
 
 class AtlaskitSelect extends React.Component<Field> {
   render() {
@@ -68,7 +68,6 @@ class AtlaskitSelect extends React.Component<Field> {
       <AkField
         name={name}
         label={label}
-        helperText={description}
         isRequired={required}
         isInvalid={isInvalid}
         invalidMessage={errorMessages}
@@ -97,7 +96,12 @@ class AtlaskitSelect extends React.Component<Field> {
               isRequired={required}
               shouldFitContainer={shouldFitContainer}
             />
-            {isInvalid && <ErrorMessage>{errorMessages}</ErrorMessage>}
+
+            {isInvalid ? (
+              <ErrorMessage>{errorMessages}</ErrorMessage>
+            ) : (
+              <HelperMessage>{description}</HelperMessage>
+            )}
           </React.Fragment>
         )}
       </AkField>


### PR DESCRIPTION
This fixes #65 by switching to use the HelperMessage component. This change is required following updates to Atlaskit.