### PR TITLE
Adding appearance prop to FormButton

### DIFF
--- a/packages/atlaskit/src/components/buttons/FormButton.js
+++ b/packages/atlaskit/src/components/buttons/FormButton.js
@@ -6,10 +6,16 @@ import type { FormValue, FormButtonProps } from "react-forms-processor";
 
 class FormButton extends React.Component<FormButtonProps> {
   render() {
-    const { isValid, label = "OK", onClick, value = {} } = this.props;
+    const {
+      appearance = "primary",
+      isValid,
+      label = "OK",
+      onClick,
+      value = {}
+    } = this.props;
     return (
       <Button
-        appearance="primary"
+        appearance={appearance}
         isDisabled={!isValid}
         onClick={() => onClick && onClick(value)}
       >

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -12,10 +12,11 @@ export type {
 } from "./types";
 
 export type FormButtonProps = {
+  appearance?: string,
+  isValid?: boolean,
   label?: string,
   onClick: (value: FormValue) => void,
-  value?: FormValue,
-  isValid?: boolean
+  value?: FormValue
 };
 
 export type Value = any;
@@ -216,7 +217,7 @@ export type FieldDef = {
   trimValue?: boolean,
   touched?: boolean, // TODO: Should this actually be on field?
   autofocus?: boolean,
-  shouldFitContainer?: boolean,
+  shouldFitContainer?: boolean
 };
 
 export type Field = FieldDef & {


### PR DESCRIPTION
By passing the appearance as a property, it will allow us to use AtlasKit preset appearances such as "danger", "subtle" instead of replicating the appearance by using CSS.